### PR TITLE
Adding my Archi file with technology and trust diagrams

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # toop-goopra-models
-TOPP GOOPRA
+TOOP GOOPRA

--- a/TOOP Architecture.archimate
+++ b/TOOP Architecture.archimate
@@ -1,0 +1,1203 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<archimate:model xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:archimate="http://www.archimatetool.com/archimate" name="TOOP Architecture" id="8a5c8fb2-3aec-4107-8598-d83b4c4e74c7" version="4.0.0">
+  <folder name="Strategy" id="2948fb9e-22fc-4586-bd36-4d3fb03a38cc" type="strategy"/>
+  <folder name="Business" id="586b2e08-b532-478c-b52f-9bfb939b2981" type="business">
+    <element xsi:type="archimate:BusinessRole" name="User" id="fad8e664-4fad-4d4a-9a10-74c710c3b97a"/>
+    <element xsi:type="archimate:BusinessRole" name="Data Consumer" id="9f9e46c6-ae4d-4a85-9885-c350181a7f9e"/>
+    <element xsi:type="archimate:BusinessProcess" name="Execute Public Service" id="0d63a4ac-c4aa-40ff-8653-14d682a5531f"/>
+    <element xsi:type="archimate:BusinessProcess" name="Ask for data retrieval from other authority" id="445db22c-cb8a-48ea-81c6-dbc99399fa91"/>
+    <element xsi:type="archimate:BusinessProcess" name="Ask for consent to retrieve personal data" id="542c9c45-139b-415b-9888-5dbbb4bb03ff"/>
+    <element xsi:type="archimate:BusinessProcess" name="Find and retrieve data from data provider" id="6bc58486-8d4c-49ae-acf9-5113c4688d0a"/>
+    <element xsi:type="archimate:BusinessEvent" name="Need for data already provided to data provider" id="5711d3c1-4238-4c90-af05-6238458b576b"/>
+    <element xsi:type="archimate:BusinessObject" name="Explicit Request" id="53ac573b-bada-4a1a-8eb5-debaa24d3809"/>
+    <element xsi:type="archimate:BusinessObject" name="Consent" id="95d4f54d-d61a-494e-9ae7-f04687e1e0f7"/>
+    <element xsi:type="archimate:BusinessProcess" name="Authenticate user" id="9c559689-3063-4980-ba54-6c6571fdfafa"/>
+    <element xsi:type="archimate:BusinessObject" name="Identity" id="030bea1c-c47c-49f8-89d6-8cd8d8929cf8"/>
+    <element xsi:type="archimate:BusinessObject" name="Data Request" id="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508"/>
+    <element xsi:type="archimate:BusinessRole" name="Data Provider" id="8a97d09b-a4db-47f1-bf36-d3dc84e0f234"/>
+    <element xsi:type="archimate:BusinessService" name="eDelivery Service" id="ef17e0d7-bed7-4f7f-8462-f4d07d2a2d69"/>
+    <element xsi:type="archimate:BusinessRole" name="Access Point Provider (DC)" id="95eb3e6f-f928-49ae-8c1e-008b3a677158"/>
+    <element xsi:type="archimate:BusinessService" name="eDelivery Service" id="12b4c919-6fb8-4009-a99b-306bbb3cf5dd"/>
+    <element xsi:type="archimate:BusinessRole" name="Access Point Provider (DP)" id="95b78242-cd23-445d-af51-41409c4f20c6"/>
+    <element xsi:type="archimate:BusinessObject" name="AS4 Message" id="40566433-b208-4b0b-ab2f-ac56863fa713"/>
+    <element xsi:type="archimate:BusinessProcess" name="Provide data" id="a2307ac8-440f-4e9d-94ec-310d20b36df8"/>
+    <element xsi:type="archimate:BusinessProcess" name="FInd data of user" id="727c636e-94a8-4af8-9af6-04bcec1e3143"/>
+    <element xsi:type="archimate:BusinessProcess" name="Check legitimacy of request" id="52a66463-82a1-4de1-8405-57da30cbfd3b"/>
+    <element xsi:type="archimate:BusinessProcess" name="Send response" id="c89398a3-0a96-4369-a8c0-b7fbbccf232c"/>
+    <element xsi:type="archimate:BusinessObject" name="Requested Data" id="1b0685dc-27ec-49a5-8dad-448356ff10ef"/>
+    <element xsi:type="archimate:BusinessRole" name="Certificate Authority" id="80a99a8e-fb62-4313-a07a-806f36458f24"/>
+    <element xsi:type="archimate:BusinessRole" name="Competent Authority" id="850c5bb7-f0c1-45ba-871f-daa2fd9c4be3"/>
+    <element xsi:type="archimate:BusinessRole" name="SMP Service Provider" id="cd190536-c093-4a49-99d6-a8cbb5de0876"/>
+    <element xsi:type="archimate:BusinessRole" name="Access Point Provider" id="487a932a-1d31-45a6-83d3-4a9a28854c90"/>
+  </folder>
+  <folder name="Application" id="14ecd00d-adbb-4a53-8985-eb26c7380878" type="application">
+    <element xsi:type="archimate:ApplicationComponent" name="Data Consumer System" id="c69264a3-6790-4058-8056-d7654ae77a75"/>
+    <element xsi:type="archimate:ApplicationComponent" name="Data Provider System" id="0984a188-6642-400c-a42f-20277624eee9"/>
+    <element xsi:type="archimate:DataObject" name="Data Consumer's Certificate" id="8c13ed65-5ac1-4785-aed2-0ad35e10e96e"/>
+    <element xsi:type="archimate:DataObject" name="TOOP Data Request" id="c950ad79-d64f-44de-96f5-c8c2e5567fd1"/>
+    <element xsi:type="archimate:ApplicationProcess" name="Seal the TOOP Data Request" id="e7bc1ccd-f2c9-4d69-a857-72a1056a19e7"/>
+    <element xsi:type="archimate:ApplicationProcess" name="Verify seal of the TOOP Data Request" id="ebe8815f-5659-458b-be8d-65ac0baf21c2"/>
+    <element xsi:type="archimate:ApplicationComponent" name="TOOP eDelivery Access Point (DC)" id="840d39d9-5dbd-485f-aecf-6a54b9185760"/>
+    <element xsi:type="archimate:ApplicationProcess" name="Verify Data Consumer" id="111e43d6-e4e3-4c68-a8b7-3abc8ef38cfa"/>
+    <element xsi:type="archimate:DataObject" name="AS4 Message" id="1ff4e70e-c2a6-4571-b700-c56d647e574b"/>
+    <element xsi:type="archimate:ApplicationProcess" name="Send message" id="c04d706c-fba8-492c-a0d1-55f187cef654"/>
+    <element xsi:type="archimate:DataObject" name="Access Point Provider's Certificate" id="0de99420-0252-4788-8732-ee96f9f5e8b9"/>
+    <element xsi:type="archimate:ApplicationProcess" name="Seal the AS4 message" id="d60feff7-3cf7-4158-9daa-f55098646351"/>
+    <element xsi:type="archimate:ApplicationComponent" name="TOOP eDelivery Access Point (DP)" id="83a924b3-9966-43f7-a838-87760185a97e"/>
+    <element xsi:type="archimate:ApplicationProcess" name="Verify the  seal of the AS4 message" id="dccb663c-584f-44ac-8d1e-e3d126f79772"/>
+    <element xsi:type="archimate:ApplicationProcess" name="Deliver message" id="fca5d997-034e-454b-bb0f-195a06ff0053"/>
+    <element xsi:type="archimate:ApplicationProcess" name="Verify Data Provider" id="58f40f88-a7c0-466f-bcff-f088a7ae2879"/>
+    <element xsi:type="archimate:ApplicationComponent" name="TOOP Connector" id="1480bf3c-d41d-4fea-827b-9ef9f79e6f49"/>
+    <element xsi:type="archimate:ApplicationComponent" name="eIDAS Node" id="5e3cba4d-6785-4a6a-80e7-ccabcb45c0e3"/>
+    <element xsi:type="archimate:ApplicationComponent" name="SMP (DC)" id="2cc22b82-8760-46b4-80cb-118fb3cb04ee"/>
+    <element xsi:type="archimate:ApplicationComponent" name="SMP (DP)" id="9dc22627-f969-46c8-ac76-9f1ac9b35767"/>
+    <element xsi:type="archimate:ApplicationComponent" name="TOOP Directory" id="83a086f5-68c0-475d-88e8-c53fc033a533"/>
+    <element xsi:type="archimate:ApplicationComponent" name="AS Access Point (DC)" id="b7b2aa18-f4d7-4341-945c-03837cb989a6"/>
+    <element xsi:type="archimate:ApplicationComponent" name="AS Access Point (DP)" id="7c846708-edd4-4a3a-afad-a711b21abeb4"/>
+    <element xsi:type="archimate:ApplicationComponent" name="eIDAS Node" id="197d58a5-2131-41e0-8ec3-37bc46ed9b3d"/>
+    <element xsi:type="archimate:ApplicationComponent" name="Semantic Mapping Service" id="5647d2da-812c-4a0f-af6e-bac94daa4aeb"/>
+    <element xsi:type="archimate:DataObject" name="Competent Authority Certificate" id="cf368aea-2632-472e-93fd-9283417f526a"/>
+    <element xsi:type="archimate:ApplicationComponent" name="SMP" id="807ead6b-5921-4901-85ba-5aec2455149c"/>
+    <element xsi:type="archimate:DataObject" name="SMP Provider Certificate" id="8fce2f71-c778-48e6-8182-fc92696647d7"/>
+    <element xsi:type="archimate:DataObject" name="Trust List" id="47712a4b-32c0-401d-887e-b659374a7166"/>
+    <element xsi:type="archimate:ApplicationComponent" name="BDXL" id="40e6d34e-02c4-4b57-8af3-a3bfc8c89962"/>
+    <element xsi:type="archimate:ApplicationService" name="Register SMP" id="c96b9e24-98ca-466d-a2d2-84993b348d01"/>
+    <element xsi:type="archimate:DataObject" name="SMP Certificate" id="013f493e-1497-459f-96e7-e31942157778"/>
+    <element xsi:type="archimate:ApplicationProcess" name="SMP Validation" id="ac982ce3-98bb-468b-a594-1f4463e9babb"/>
+    <element xsi:type="archimate:ApplicationProcess" name="SMP Registration" id="46993d29-c622-4da9-a827-613b19e05632"/>
+    <element xsi:type="archimate:ApplicationProcess" name="Publish SMP location" id="5039ff23-50cf-45d4-adba-913033c25087"/>
+    <element xsi:type="archimate:ApplicationService" name="Publish meta-data" id="f32e715b-c735-4cf9-95d5-442183d6a78e"/>
+    <element xsi:type="archimate:ApplicationFunction" name="Routing Metadata Discovery" id="ff508064-92fe-4e22-af13-af192add8998"/>
+    <element xsi:type="archimate:DataObject" name="Signed meta-data" id="00da5f43-6209-4b90-98b6-66f241f28bc1"/>
+    <element xsi:type="archimate:DataObject" name="AP Provider (DC) Certificate" id="c0b1a8e1-f208-4c52-ba6e-5b1831bd8ff8"/>
+    <element xsi:type="archimate:DataObject" name="AS4 Receipt" id="b05b5406-553d-4861-9f0d-9dfdce3907fc"/>
+    <element xsi:type="archimate:DataObject" name="AP Provider (DP) Certificate" id="145becdc-6985-48c4-a520-a423ae80ec59"/>
+    <element xsi:type="archimate:DataObject" name="SMP Meta-data" id="108c2382-e2bf-4950-93ba-10e61c915592"/>
+  </folder>
+  <folder name="Technology &amp; Physical" id="b37c3ce8-e970-4b27-9c32-83c4e3835745" type="technology">
+    <element xsi:type="archimate:Node" name="Data Consumer System" id="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
+    <element xsi:type="archimate:Node" name="Access Point (DC)" id="c2bcebbc-2082-490d-aa5f-8606e59e3833"/>
+    <element xsi:type="archimate:SystemSoftware" name="AS4 Message Service Handler" id="cc875beb-f4ff-4952-9600-5eae35fb0d10"/>
+    <element xsi:type="archimate:Node" name="SMP Server (DC)" id="a46b13f6-899f-4651-bccd-67685ea0ab9d"/>
+    <element xsi:type="archimate:SystemSoftware" name="SMP Service Implementation" id="8efc3e85-150e-4e1d-91f5-8989b1c5b89f"/>
+    <element xsi:type="archimate:Node" name="TOOP Directory Server" id="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe"/>
+    <element xsi:type="archimate:TechnologyCollaboration" name="TOOP Directory Service Implementation" id="10cb9a93-25d4-4da1-8964-c183b3ff910c"/>
+    <element xsi:type="archimate:Node" name="BDXL Server" id="98f08e2a-55bb-4cf3-88f8-a72c328068e1"/>
+    <element xsi:type="archimate:Node" name="DNS Server" id="8532f211-fbcb-4255-a32d-91871c7336be"/>
+    <element xsi:type="archimate:Node" name="DC's MS eIDAS Node Server" id="538aa797-e00b-442f-af83-9a8e7e85aadd"/>
+    <element xsi:type="archimate:TechnologyCollaboration" name="eIDAS Node Service Implementation" id="aae5673b-3220-4959-bd3b-a4351a94194d"/>
+    <element xsi:type="archimate:Path" name="Path" id="eccb71dc-aeb4-453c-842e-ca1ee7c058f4"/>
+    <element xsi:type="archimate:TechnologyCollaboration" name="BDXL Back-end interface" id="e573296a-1aac-4c71-871c-1baf2417c996"/>
+    <element xsi:type="archimate:Node" name="SMP Server (DP)" id="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d"/>
+    <element xsi:type="archimate:SystemSoftware" name="SMP Service Implementation" id="1a8879f8-06ce-4925-93ab-ff2222e347aa"/>
+    <element xsi:type="archimate:Node" name="DP's MS eIDAS Node Server" id="69efba2e-88ec-4e92-a231-8d4bb02b8abb"/>
+    <element xsi:type="archimate:TechnologyCollaboration" name="eIDAS Node Service Implementation" id="68e59636-1f53-4336-9cfd-64fa6acae825"/>
+    <element xsi:type="archimate:Node" name="Data Provider System" id="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e"/>
+    <element xsi:type="archimate:Node" name="Access Point (DP)" id="ca49e61c-53cc-4599-b5fd-f30b80485328"/>
+    <element xsi:type="archimate:SystemSoftware" name="AS4 Message Service Handler" id="51eacaa9-ed7b-4307-915c-05a114b2a19d"/>
+    <element xsi:type="archimate:Node" name="Semantic Server" id="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349"/>
+    <element xsi:type="archimate:SystemSoftware" name="Semantic Service Implementation" id="fede8dba-b24e-4347-9487-e9901da917f9"/>
+    <element xsi:type="archimate:SystemSoftware" name="AS4 Message Service Handler (copy)" id="e76439ba-7936-4967-a722-087de88be585"/>
+    <element xsi:type="archimate:CommunicationNetwork" name="National Network of DC" id="556907f5-b628-43fb-845c-db9cb756483a"/>
+    <element xsi:type="archimate:CommunicationNetwork" name="Internet" id="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
+    <element xsi:type="archimate:CommunicationNetwork" name="LAN" id="d61e514e-6042-4efb-8e3a-ab4c7f021115"/>
+    <element xsi:type="archimate:CommunicationNetwork" name="eIDAS network" id="ec24ee51-08ed-465b-a883-ae6776b24eb8"/>
+    <element xsi:type="archimate:CommunicationNetwork" name="National Network of DP" id="f925eb37-dc1e-4ab2-a179-808b431dcb0c"/>
+    <element xsi:type="archimate:Node" name="Central Trust List Server" id="64672752-1b6b-4fd1-ab2f-9f8eff29d024"/>
+    <element xsi:type="archimate:Node" name="Member State Trust List Server" id="17bc30f6-6291-43bc-b2e5-ef5202bc18e4"/>
+    <element xsi:type="archimate:Node" name="Member State Trust List Server (copy)" id="819e7e8c-a185-4b7b-b205-940fefcfe408"/>
+  </folder>
+  <folder name="Motivation" id="e3dd0cb4-7b89-407a-9393-dbb9f347b6ec" type="motivation"/>
+  <folder name="Implementation &amp; Migration" id="e6f65253-9459-48a8-a9f0-e9755b2e86fc" type="implementation_migration"/>
+  <folder name="Other" id="1f12370d-3436-4882-9244-fabf37f7c051" type="other">
+    <element xsi:type="archimate:Junction" name="Junction" id="38b61099-7009-443e-b2df-761194403fc9"/>
+    <element xsi:type="archimate:Junction" name="Junction" id="d4fc0cff-64bd-47c2-be39-0d20e234a2dd"/>
+    <element xsi:type="archimate:Location" name="DC's Member State" id="212f31b8-928f-4714-8aa2-542ecdb81468"/>
+    <element xsi:type="archimate:Location" name="Central" id="efbf9f7a-7b30-462f-a471-3cc2049014b5"/>
+    <element xsi:type="archimate:Location" name="DP's Member State" id="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac"/>
+  </folder>
+  <folder name="Relations" id="581cce27-5db4-48ae-ad98-a7fe7eea68c3" type="relations">
+    <element xsi:type="archimate:CompositionRelationship" id="46975254-c3e9-4883-8aa3-3169ed3d7c29" source="0d63a4ac-c4aa-40ff-8653-14d682a5531f" target="445db22c-cb8a-48ea-81c6-dbc99399fa91"/>
+    <element xsi:type="archimate:ServingRelationship" id="743fde0d-4f10-435e-b6ea-04be25793ed4" source="0d63a4ac-c4aa-40ff-8653-14d682a5531f" target="fad8e664-4fad-4d4a-9a10-74c710c3b97a"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="04909a89-4d80-4f31-b9de-3d210fe7ed6c" source="9f9e46c6-ae4d-4a85-9885-c350181a7f9e" target="0d63a4ac-c4aa-40ff-8653-14d682a5531f"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="e90bbf63-7edb-421c-b6c8-2f694dc54642" source="445db22c-cb8a-48ea-81c6-dbc99399fa91" target="38b61099-7009-443e-b2df-761194403fc9"/>
+    <element xsi:type="archimate:CompositionRelationship" id="7247a8bd-1ef3-469b-a1ba-f1a7b7b52bb1" source="0d63a4ac-c4aa-40ff-8653-14d682a5531f" target="542c9c45-139b-415b-9888-5dbbb4bb03ff"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="5ce00bed-a816-46ec-852c-8b08ffd09313" source="38b61099-7009-443e-b2df-761194403fc9" target="542c9c45-139b-415b-9888-5dbbb4bb03ff"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="5205c941-97bc-4e24-99a5-6ef8e130b32e" source="542c9c45-139b-415b-9888-5dbbb4bb03ff" target="d4fc0cff-64bd-47c2-be39-0d20e234a2dd"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="ff5a9d5f-d965-4e18-9cff-c0585ea91588" source="38b61099-7009-443e-b2df-761194403fc9" target="d4fc0cff-64bd-47c2-be39-0d20e234a2dd"/>
+    <element xsi:type="archimate:CompositionRelationship" id="7e54ed44-7028-4eae-bb37-e4d806adce10" source="0d63a4ac-c4aa-40ff-8653-14d682a5531f" target="6bc58486-8d4c-49ae-acf9-5113c4688d0a"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="775b4d4c-00cc-422d-bac0-1cda4fd75754" source="d4fc0cff-64bd-47c2-be39-0d20e234a2dd" target="6bc58486-8d4c-49ae-acf9-5113c4688d0a"/>
+    <element xsi:type="archimate:CompositionRelationship" id="a9b35bc6-28cd-43e7-8e11-f2a7f7717f59" source="0d63a4ac-c4aa-40ff-8653-14d682a5531f" target="9c559689-3063-4980-ba54-6c6571fdfafa"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="77260656-6e53-49a3-ba8b-50950c55b2e9" source="5711d3c1-4238-4c90-af05-6238458b576b" target="9c559689-3063-4980-ba54-6c6571fdfafa"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="85a1d04f-8d78-45c3-96af-7eb8da2de5bb" source="9c559689-3063-4980-ba54-6c6571fdfafa" target="445db22c-cb8a-48ea-81c6-dbc99399fa91"/>
+    <element xsi:type="archimate:AccessRelationship" id="d5e09a47-9af8-40b6-b997-b8d222fbd40c" source="9c559689-3063-4980-ba54-6c6571fdfafa" target="030bea1c-c47c-49f8-89d6-8cd8d8929cf8"/>
+    <element xsi:type="archimate:AccessRelationship" id="ebaeef97-a5a7-4a12-9300-5385ee892937" source="445db22c-cb8a-48ea-81c6-dbc99399fa91" target="53ac573b-bada-4a1a-8eb5-debaa24d3809"/>
+    <element xsi:type="archimate:AccessRelationship" id="61bca2c7-2f9f-4dbc-836c-9161369dd62d" source="542c9c45-139b-415b-9888-5dbbb4bb03ff" target="95d4f54d-d61a-494e-9ae7-f04687e1e0f7"/>
+    <element xsi:type="archimate:AccessRelationship" id="43f0f298-99a7-41e5-b998-5ae8ae89e0ca" source="6bc58486-8d4c-49ae-acf9-5113c4688d0a" target="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508"/>
+    <element xsi:type="archimate:AggregationRelationship" id="c576ed23-6c2d-41e8-9c2b-b70f55934df1" source="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508" target="95d4f54d-d61a-494e-9ae7-f04687e1e0f7"/>
+    <element xsi:type="archimate:AggregationRelationship" id="259a3bae-99c7-4af9-8754-aa31175d39db" source="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508" target="53ac573b-bada-4a1a-8eb5-debaa24d3809"/>
+    <element xsi:type="archimate:AggregationRelationship" id="72639f88-abea-4c10-bbbe-f33e1209959c" source="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508" target="030bea1c-c47c-49f8-89d6-8cd8d8929cf8"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="c7a4cf3e-b1b4-40bd-8879-3f5d7ef45d37" source="5711d3c1-4238-4c90-af05-6238458b576b" target="6bc58486-8d4c-49ae-acf9-5113c4688d0a"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="c9e10f16-7115-4cbe-9752-1a5cd6d6996d" source="95eb3e6f-f928-49ae-8c1e-008b3a677158" target="ef17e0d7-bed7-4f7f-8462-f4d07d2a2d69"/>
+    <element xsi:type="archimate:ServingRelationship" id="dd8cdaff-6f27-499c-b3a6-2078e3aa3b9c" source="ef17e0d7-bed7-4f7f-8462-f4d07d2a2d69" target="6bc58486-8d4c-49ae-acf9-5113c4688d0a"/>
+    <element xsi:type="archimate:FlowRelationship" id="0be45e23-ff6e-4fb1-9de3-8d85cee0ba19" source="6bc58486-8d4c-49ae-acf9-5113c4688d0a" target="ef17e0d7-bed7-4f7f-8462-f4d07d2a2d69"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="f9423481-da51-43ab-b957-72d82a037631" source="95b78242-cd23-445d-af51-41409c4f20c6" target="12b4c919-6fb8-4009-a99b-306bbb3cf5dd"/>
+    <element xsi:type="archimate:AggregationRelationship" id="96ba3f91-051d-47bc-9dde-03e4431135a3" source="40566433-b208-4b0b-ab2f-ac56863fa713" target="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508"/>
+    <element xsi:type="archimate:AccessRelationship" id="8c213188-eec1-4a90-8dcd-a42383a94e38" source="ef17e0d7-bed7-4f7f-8462-f4d07d2a2d69" target="40566433-b208-4b0b-ab2f-ac56863fa713"/>
+    <element xsi:type="archimate:AccessRelationship" id="120dd2f9-7cd5-4b9e-a58b-7054bd65a052" source="12b4c919-6fb8-4009-a99b-306bbb3cf5dd" target="40566433-b208-4b0b-ab2f-ac56863fa713" accessType="1"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="7226f430-eda2-4e1e-bf19-3a9117613bb5" source="8a97d09b-a4db-47f1-bf36-d3dc84e0f234" target="a2307ac8-440f-4e9d-94ec-310d20b36df8"/>
+    <element xsi:type="archimate:AccessRelationship" id="4646b9a5-e538-4964-87b4-ff32fa20fa01" source="a2307ac8-440f-4e9d-94ec-310d20b36df8" target="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508" accessType="1"/>
+    <element xsi:type="archimate:FlowRelationship" id="0008c8e1-fda3-458b-bd9b-a9a56468a258" source="12b4c919-6fb8-4009-a99b-306bbb3cf5dd" target="a2307ac8-440f-4e9d-94ec-310d20b36df8"/>
+    <element xsi:type="archimate:CompositionRelationship" id="8f45d271-86d5-4609-95cc-008e96b631e0" source="a2307ac8-440f-4e9d-94ec-310d20b36df8" target="727c636e-94a8-4af8-9af6-04bcec1e3143"/>
+    <element xsi:type="archimate:CompositionRelationship" id="bc0c881b-2587-4c7d-820f-99ab59a701b4" source="a2307ac8-440f-4e9d-94ec-310d20b36df8" target="52a66463-82a1-4de1-8405-57da30cbfd3b"/>
+    <element xsi:type="archimate:FlowRelationship" id="082ca924-afd4-4633-bae9-551d325a5aac" source="52a66463-82a1-4de1-8405-57da30cbfd3b" target="727c636e-94a8-4af8-9af6-04bcec1e3143"/>
+    <element xsi:type="archimate:CompositionRelationship" id="9d9dca79-9456-48e7-99b0-e6401a71d55d" source="a2307ac8-440f-4e9d-94ec-310d20b36df8" target="c89398a3-0a96-4369-a8c0-b7fbbccf232c"/>
+    <element xsi:type="archimate:AccessRelationship" id="e0ac69dc-fcd3-4ec6-9f11-14490b4acf63" source="c89398a3-0a96-4369-a8c0-b7fbbccf232c" target="1b0685dc-27ec-49a5-8dad-448356ff10ef"/>
+    <element xsi:type="archimate:AccessRelationship" id="1b62e40b-6cce-4920-b99c-cb53245bebc6" source="0d63a4ac-c4aa-40ff-8653-14d682a5531f" target="1b0685dc-27ec-49a5-8dad-448356ff10ef" accessType="1"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="72eeaacb-7f3c-4419-b196-770252a0777e" source="12b4c919-6fb8-4009-a99b-306bbb3cf5dd" target="a2307ac8-440f-4e9d-94ec-310d20b36df8"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="c00dabfa-1e04-4dd3-b160-d62a1bbf9237" source="727c636e-94a8-4af8-9af6-04bcec1e3143" target="c89398a3-0a96-4369-a8c0-b7fbbccf232c"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="7f81d755-9b4d-4232-8557-3cefe31f5e0d" source="52a66463-82a1-4de1-8405-57da30cbfd3b" target="727c636e-94a8-4af8-9af6-04bcec1e3143"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="3c4793d1-7323-442f-82b1-b8df2d720110" source="445db22c-cb8a-48ea-81c6-dbc99399fa91" target="542c9c45-139b-415b-9888-5dbbb4bb03ff"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="1a6c5e38-43e7-421d-8b88-000ad22bea39" source="542c9c45-139b-415b-9888-5dbbb4bb03ff" target="6bc58486-8d4c-49ae-acf9-5113c4688d0a"/>
+    <element xsi:type="archimate:AssociationRelationship" name="has been issued a" id="e1e988a6-73c8-4563-8cee-37fa9b8017d1" source="9f9e46c6-ae4d-4a85-9885-c350181a7f9e" target="8c13ed65-5ac1-4785-aed2-0ad35e10e96e"/>
+    <element xsi:type="archimate:AccessRelationship" id="39d64881-7f81-467e-975c-4298a395051d" source="e7bc1ccd-f2c9-4d69-a857-72a1056a19e7" target="c950ad79-d64f-44de-96f5-c8c2e5567fd1"/>
+    <element xsi:type="archimate:AccessRelationship" id="8dcae5d1-d852-4d66-8c74-4cc311a49dfd" source="ebe8815f-5659-458b-be8d-65ac0baf21c2" target="c950ad79-d64f-44de-96f5-c8c2e5567fd1" accessType="1"/>
+    <element xsi:type="archimate:AccessRelationship" id="92a66d4a-1b5a-4d61-b4d2-dd37d5d00a3c" source="ebe8815f-5659-458b-be8d-65ac0baf21c2" target="8c13ed65-5ac1-4785-aed2-0ad35e10e96e" accessType="1"/>
+    <element xsi:type="archimate:AccessRelationship" id="aea5772d-9e38-45b2-a1b3-0e63bbe875ef" source="e7bc1ccd-f2c9-4d69-a857-72a1056a19e7" target="8c13ed65-5ac1-4785-aed2-0ad35e10e96e" accessType="1"/>
+    <element xsi:type="archimate:ServingRelationship" id="61505492-a12a-41d8-a385-6141c37992e7" source="0984a188-6642-400c-a42f-20277624eee9" target="8a97d09b-a4db-47f1-bf36-d3dc84e0f234"/>
+    <element xsi:type="archimate:ServingRelationship" id="ba2b56e1-2552-4374-96d4-99eed3ead52b" source="c69264a3-6790-4058-8056-d7654ae77a75" target="9f9e46c6-ae4d-4a85-9885-c350181a7f9e"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="40e2396d-2bc8-4117-9fcd-c7b661f834b6" source="c69264a3-6790-4058-8056-d7654ae77a75" target="e7bc1ccd-f2c9-4d69-a857-72a1056a19e7"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="7d6df378-e814-49f3-91e5-cbf1f9042af9" source="0984a188-6642-400c-a42f-20277624eee9" target="ebe8815f-5659-458b-be8d-65ac0baf21c2"/>
+    <element xsi:type="archimate:AssociationRelationship" name="used for sealing" id="3ed190cb-3ea5-4d07-9c1a-01125aae0908" source="8c13ed65-5ac1-4785-aed2-0ad35e10e96e" target="c950ad79-d64f-44de-96f5-c8c2e5567fd1"/>
+    <element xsi:type="archimate:CompositionRelationship" id="f5979514-73cb-4fec-933b-e5c0c08eb348" source="c04d706c-fba8-492c-a0d1-55f187cef654" target="111e43d6-e4e3-4c68-a8b7-3abc8ef38cfa"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="a6a1675b-1183-4308-86e7-176a7a1c38d4" source="840d39d9-5dbd-485f-aecf-6a54b9185760" target="c04d706c-fba8-492c-a0d1-55f187cef654"/>
+    <element xsi:type="archimate:ServingRelationship" id="e8194e02-47ed-4782-840b-f301f26b9e57" source="c04d706c-fba8-492c-a0d1-55f187cef654" target="c69264a3-6790-4058-8056-d7654ae77a75"/>
+    <element xsi:type="archimate:ServingRelationship" id="7d371c26-b1db-47ae-acce-6300aa44dd6b" source="840d39d9-5dbd-485f-aecf-6a54b9185760" target="95eb3e6f-f928-49ae-8c1e-008b3a677158"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="c1b032d3-c50d-4ed6-a101-e4e03879c74b" source="840d39d9-5dbd-485f-aecf-6a54b9185760" target="d60feff7-3cf7-4158-9daa-f55098646351"/>
+    <element xsi:type="archimate:AccessRelationship" id="873d928f-fae0-48e8-92c6-c9b08b331775" source="840d39d9-5dbd-485f-aecf-6a54b9185760" target="1ff4e70e-c2a6-4571-b700-c56d647e574b"/>
+    <element xsi:type="archimate:AccessRelationship" id="e14c0b3b-6f53-4a7f-86b4-5ece2e19d297" source="d60feff7-3cf7-4158-9daa-f55098646351" target="0de99420-0252-4788-8732-ee96f9f5e8b9" accessType="1"/>
+    <element xsi:type="archimate:AssociationRelationship" name="sealed using" id="25d43edc-de81-45a6-8c74-479a4d3894f9" source="0de99420-0252-4788-8732-ee96f9f5e8b9" target="1ff4e70e-c2a6-4571-b700-c56d647e574b"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="61bad181-0237-4bae-af98-0cb28e29a757" source="83a924b3-9966-43f7-a838-87760185a97e" target="dccb663c-584f-44ac-8d1e-e3d126f79772"/>
+    <element xsi:type="archimate:CompositionRelationship" id="fdbefc6e-6ab9-4cce-bee2-307bb69486e2" source="fca5d997-034e-454b-bb0f-195a06ff0053" target="58f40f88-a7c0-466f-bcff-f088a7ae2879"/>
+    <element xsi:type="archimate:ServingRelationship" id="233acd57-bae1-4da8-affb-f861254c2cb6" source="83a924b3-9966-43f7-a838-87760185a97e" target="95b78242-cd23-445d-af51-41409c4f20c6"/>
+    <element xsi:type="archimate:AccessRelationship" id="2324f816-d7aa-4ae5-b233-6ec580157784" source="83a924b3-9966-43f7-a838-87760185a97e" target="1ff4e70e-c2a6-4571-b700-c56d647e574b" accessType="1"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="4ffb4c4f-dd99-4ce1-878f-5d2b51132ce3" source="83a924b3-9966-43f7-a838-87760185a97e" target="fca5d997-034e-454b-bb0f-195a06ff0053"/>
+    <element xsi:type="archimate:ServingRelationship" id="4504f86c-17f7-4b9b-93a8-81363473e011" source="fca5d997-034e-454b-bb0f-195a06ff0053" target="0984a188-6642-400c-a42f-20277624eee9"/>
+    <element xsi:type="archimate:AccessRelationship" id="1dbd287d-01da-4eba-9d63-20abfc405a33" source="c69264a3-6790-4058-8056-d7654ae77a75" target="c950ad79-d64f-44de-96f5-c8c2e5567fd1"/>
+    <element xsi:type="archimate:AccessRelationship" id="c649fa7f-0a20-43ce-b1ec-a0b4bb39a5e7" source="0984a188-6642-400c-a42f-20277624eee9" target="c950ad79-d64f-44de-96f5-c8c2e5567fd1" accessType="1"/>
+    <element xsi:type="archimate:AccessRelationship" id="c3950612-5080-4d28-b276-2cec37cd5b2c" source="dccb663c-584f-44ac-8d1e-e3d126f79772" target="0de99420-0252-4788-8732-ee96f9f5e8b9" accessType="1"/>
+    <element xsi:type="archimate:AggregationRelationship" id="c14f095b-81e3-4f6a-9ee5-001b7b4e21a3" source="1ff4e70e-c2a6-4571-b700-c56d647e574b" target="c950ad79-d64f-44de-96f5-c8c2e5567fd1"/>
+    <element xsi:type="archimate:FlowRelationship" id="3af58bef-a455-47b9-8aae-b838767f6614" source="ef17e0d7-bed7-4f7f-8462-f4d07d2a2d69" target="12b4c919-6fb8-4009-a99b-306bbb3cf5dd"/>
+    <element xsi:type="archimate:AssociationRelationship" name="has been issued a" id="b76f75f6-e675-49a7-b393-b0c619a31eca" source="95eb3e6f-f928-49ae-8c1e-008b3a677158" target="0de99420-0252-4788-8732-ee96f9f5e8b9"/>
+    <element xsi:type="archimate:CompositionRelationship" id="c63e1909-e2fe-4516-b642-d6749c9ad79c" source="c2bcebbc-2082-490d-aa5f-8606e59e3833" target="cc875beb-f4ff-4952-9600-5eae35fb0d10"/>
+    <element xsi:type="archimate:CompositionRelationship" id="6652b746-6c44-479c-b3e9-5f901199d7ef" source="a46b13f6-899f-4651-bccd-67685ea0ab9d" target="8efc3e85-150e-4e1d-91f5-8989b1c5b89f"/>
+    <element xsi:type="archimate:CompositionRelationship" id="3ca5b18c-b380-4be6-95f6-d6301b907ef5" source="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe" target="10cb9a93-25d4-4da1-8964-c183b3ff910c"/>
+    <element xsi:type="archimate:CompositionRelationship" id="49c8dabe-7bb4-4d12-b9c6-1cbd98f0c9a3" source="538aa797-e00b-442f-af83-9a8e7e85aadd" target="aae5673b-3220-4959-bd3b-a4351a94194d"/>
+    <element xsi:type="archimate:ServingRelationship" id="dbe8aa22-0fa9-4cf4-9585-78e68a698731" source="98f08e2a-55bb-4cf3-88f8-a72c328068e1" target="a46b13f6-899f-4651-bccd-67685ea0ab9d"/>
+    <element xsi:type="archimate:ServingRelationship" id="6188230a-d639-46ea-9351-4bd0e798f98e" source="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
+    <element xsi:type="archimate:ServingRelationship" id="b8077982-bc5b-42e6-baad-9a371e82443c" source="8532f211-fbcb-4255-a32d-91871c7336be" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
+    <element xsi:type="archimate:ServingRelationship" id="00c4a55a-5ec6-42e1-91fc-de97c090c9ec" source="a46b13f6-899f-4651-bccd-67685ea0ab9d" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
+    <element xsi:type="archimate:ServingRelationship" id="254d9661-8126-4963-8d40-e57116fa4186" source="c2bcebbc-2082-490d-aa5f-8606e59e3833" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
+    <element xsi:type="archimate:ServingRelationship" id="3a2019bf-1f10-4bd8-9004-073eccf5289a" source="538aa797-e00b-442f-af83-9a8e7e85aadd" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
+    <element xsi:type="archimate:CompositionRelationship" id="f4d55798-6548-4f2b-8a36-dfb103680504" source="98f08e2a-55bb-4cf3-88f8-a72c328068e1" target="e573296a-1aac-4c71-871c-1baf2417c996"/>
+    <element xsi:type="archimate:FlowRelationship" id="4ccd9580-1076-4ab8-9e7c-51b10d00aa48" source="98f08e2a-55bb-4cf3-88f8-a72c328068e1" target="8532f211-fbcb-4255-a32d-91871c7336be"/>
+    <element xsi:type="archimate:CompositionRelationship" id="dd6d220f-2e28-4568-9b32-05078dd07d50" source="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d" target="1a8879f8-06ce-4925-93ab-ff2222e347aa"/>
+    <element xsi:type="archimate:ServingRelationship" id="1a65f425-6273-4339-badf-15bc2122b7fa" source="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
+    <element xsi:type="archimate:CompositionRelationship" id="b85300bf-77ed-49c7-84a8-011be915cee2" source="69efba2e-88ec-4e92-a231-8d4bb02b8abb" target="68e59636-1f53-4336-9cfd-64fa6acae825"/>
+    <element xsi:type="archimate:ServingRelationship" id="885e9e6f-9da6-4924-8aaf-d8c5ab20552b" source="69efba2e-88ec-4e92-a231-8d4bb02b8abb" target="538aa797-e00b-442f-af83-9a8e7e85aadd"/>
+    <element xsi:type="archimate:ServingRelationship" id="3de150e4-3c9e-45ad-9c44-fc2dccf967a3" source="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d" target="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe"/>
+    <element xsi:type="archimate:ServingRelationship" id="ce7896f2-7830-4829-bc08-5d822b5ac10b" source="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d" target="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e"/>
+    <element xsi:type="archimate:ServingRelationship" id="b1837450-f7fb-4eb5-8d35-95206ec0ad1c" source="98f08e2a-55bb-4cf3-88f8-a72c328068e1" target="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d"/>
+    <element xsi:type="archimate:ServingRelationship" id="604120c2-2acc-4b05-a43d-c707a73ad5dc" source="8532f211-fbcb-4255-a32d-91871c7336be" target="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e"/>
+    <element xsi:type="archimate:CompositionRelationship" id="67b2f7a1-c01c-464b-8caa-b4a9744f35ae" source="ca49e61c-53cc-4599-b5fd-f30b80485328" target="51eacaa9-ed7b-4307-915c-05a114b2a19d"/>
+    <element xsi:type="archimate:ServingRelationship" id="59d8bd29-7642-49a0-9c2f-48b13fa3fdfc" source="ca49e61c-53cc-4599-b5fd-f30b80485328" target="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e"/>
+    <element xsi:type="archimate:ServingRelationship" id="bce71955-7d5f-4f3d-a47c-a5b0b5af71d8" source="c2bcebbc-2082-490d-aa5f-8606e59e3833" target="ca49e61c-53cc-4599-b5fd-f30b80485328"/>
+    <element xsi:type="archimate:ServingRelationship" id="0e0d90ea-f06a-414b-9eab-4e425f96d110" source="ca49e61c-53cc-4599-b5fd-f30b80485328" target="c2bcebbc-2082-490d-aa5f-8606e59e3833"/>
+    <element xsi:type="archimate:CompositionRelationship" id="3dfc3dbf-5711-45b6-930a-0dc44678676a" source="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349" target="fede8dba-b24e-4347-9487-e9901da917f9"/>
+    <element xsi:type="archimate:ServingRelationship" id="5ad8159f-f033-40fd-977d-34f2694d728b" source="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
+    <element xsi:type="archimate:ServingRelationship" id="9102c6a7-d07f-4de0-94d7-273bb7bca236" source="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349" target="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e"/>
+    <element xsi:type="archimate:AggregationRelationship" id="30ba6a82-c6d3-4a27-83ce-9d8cde8750bd" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="a46b13f6-899f-4651-bccd-67685ea0ab9d"/>
+    <element xsi:type="archimate:AggregationRelationship" id="db710967-fa2b-4904-87d4-5d28e548a07d" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
+    <element xsi:type="archimate:AggregationRelationship" id="b57e920c-ff16-47af-8706-b277376ee747" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="c2bcebbc-2082-490d-aa5f-8606e59e3833"/>
+    <element xsi:type="archimate:AggregationRelationship" id="f28c0a1d-12f1-4f22-9add-268879bc8a51" source="efbf9f7a-7b30-462f-a471-3cc2049014b5" target="8532f211-fbcb-4255-a32d-91871c7336be"/>
+    <element xsi:type="archimate:AggregationRelationship" id="b42e098e-f8e9-48a6-9786-1de691e9e707" source="efbf9f7a-7b30-462f-a471-3cc2049014b5" target="98f08e2a-55bb-4cf3-88f8-a72c328068e1"/>
+    <element xsi:type="archimate:AggregationRelationship" id="8061137c-057b-42fe-b50e-08493914d415" source="efbf9f7a-7b30-462f-a471-3cc2049014b5" target="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe"/>
+    <element xsi:type="archimate:AggregationRelationship" id="17b2804b-bcb2-400f-b93c-827ca8523d9e" source="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac" target="69efba2e-88ec-4e92-a231-8d4bb02b8abb"/>
+    <element xsi:type="archimate:AggregationRelationship" id="3fdeebe9-63d6-4c7f-911f-820cf135848c" source="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac" target="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e"/>
+    <element xsi:type="archimate:AggregationRelationship" id="a9609e08-a8e3-4e25-8f10-7e68029931d2" source="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac" target="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d"/>
+    <element xsi:type="archimate:AggregationRelationship" id="c801c856-c345-4a22-9a98-42569a3220bd" source="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac" target="ca49e61c-53cc-4599-b5fd-f30b80485328"/>
+    <element xsi:type="archimate:AssociationRelationship" id="95c2def0-63c5-47e6-a79e-2ae528a5740d" source="556907f5-b628-43fb-845c-db9cb756483a" target="a46b13f6-899f-4651-bccd-67685ea0ab9d"/>
+    <element xsi:type="archimate:AssociationRelationship" id="6ac270e4-3520-44ba-8784-77f217b03887" source="556907f5-b628-43fb-845c-db9cb756483a" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
+    <element xsi:type="archimate:AssociationRelationship" id="9063ad94-b467-48df-97c6-3d97233391ce" source="556907f5-b628-43fb-845c-db9cb756483a" target="c2bcebbc-2082-490d-aa5f-8606e59e3833"/>
+    <element xsi:type="archimate:AssociationRelationship" id="7d00fe16-6ca1-4950-8365-1945ab74a12f" source="556907f5-b628-43fb-845c-db9cb756483a" target="538aa797-e00b-442f-af83-9a8e7e85aadd"/>
+    <element xsi:type="archimate:AssociationRelationship" id="dd868d9a-3da0-43c9-b8b7-c53381a29fe1" source="d61e514e-6042-4efb-8e3a-ab4c7f021115" target="98f08e2a-55bb-4cf3-88f8-a72c328068e1"/>
+    <element xsi:type="archimate:AssociationRelationship" id="0fd499a8-dde4-49b0-a3c4-7cedc2a26d9b" source="d61e514e-6042-4efb-8e3a-ab4c7f021115" target="8532f211-fbcb-4255-a32d-91871c7336be"/>
+    <element xsi:type="archimate:AssociationRelationship" id="796bacf1-b115-4589-933c-de8ca5a60a6b" source="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba" target="a46b13f6-899f-4651-bccd-67685ea0ab9d"/>
+    <element xsi:type="archimate:AssociationRelationship" id="0d084930-9cb3-4fb4-a204-f0357d34ac4c" source="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba" target="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe"/>
+    <element xsi:type="archimate:AssociationRelationship" id="237529d5-cb2a-4d39-94f3-1b45aecb0003" source="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba" target="98f08e2a-55bb-4cf3-88f8-a72c328068e1"/>
+    <element xsi:type="archimate:AssociationRelationship" id="30c84a11-4798-4a9c-9840-d23053e7bd53" source="c2bcebbc-2082-490d-aa5f-8606e59e3833" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
+    <element xsi:type="archimate:AssociationRelationship" id="b4296792-91ba-4d9b-9625-d9437d280c57" source="8532f211-fbcb-4255-a32d-91871c7336be" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
+    <element xsi:type="archimate:AssociationRelationship" id="4dc96ee3-5458-4d17-a544-a381a62fb28a" source="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba" target="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349"/>
+    <element xsi:type="archimate:AssociationRelationship" id="27246a90-8ce3-483e-a388-fe8f927e1ca5" source="ec24ee51-08ed-465b-a883-ae6776b24eb8" target="69efba2e-88ec-4e92-a231-8d4bb02b8abb"/>
+    <element xsi:type="archimate:AssociationRelationship" id="be8eefda-496f-4f0b-8362-6f30ba84140e" source="ec24ee51-08ed-465b-a883-ae6776b24eb8" target="538aa797-e00b-442f-af83-9a8e7e85aadd"/>
+    <element xsi:type="archimate:AssociationRelationship" id="8ea14bb7-705c-4a3f-9fb7-40f18af5afbb" source="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
+    <element xsi:type="archimate:AssociationRelationship" id="496117f5-e3ac-4e8c-be72-cfcab9cc996b" source="ca49e61c-53cc-4599-b5fd-f30b80485328" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
+    <element xsi:type="archimate:AssociationRelationship" id="faf184fe-1470-45c9-9e0f-e4bc4b26aa32" source="cfe6f942-99a2-4512-bf58-9be6921adb78" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
+    <element xsi:type="archimate:AssociationRelationship" id="c03146a8-2273-424b-bc6d-c2dd86f93e5c" source="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e" target="f925eb37-dc1e-4ab2-a179-808b431dcb0c"/>
+    <element xsi:type="archimate:AssociationRelationship" id="ca528479-4583-4a63-880b-efdd032cdcb6" source="f925eb37-dc1e-4ab2-a179-808b431dcb0c" target="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d"/>
+    <element xsi:type="archimate:AssociationRelationship" id="0a90aced-35fd-499f-8aee-26de44bf636c" source="f925eb37-dc1e-4ab2-a179-808b431dcb0c" target="69efba2e-88ec-4e92-a231-8d4bb02b8abb"/>
+    <element xsi:type="archimate:AssociationRelationship" id="6b11f94c-fad5-4ef3-acde-3a77b7cc9b4b" source="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
+    <element xsi:type="archimate:AssociationRelationship" id="4565571a-58a5-4483-9551-4dc1600b45c1" source="f925eb37-dc1e-4ab2-a179-808b431dcb0c" target="ca49e61c-53cc-4599-b5fd-f30b80485328"/>
+    <element xsi:type="archimate:AggregationRelationship" id="8adf2b0b-3bd8-40ce-8a75-a5e29b7aaa84" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="556907f5-b628-43fb-845c-db9cb756483a"/>
+    <element xsi:type="archimate:AggregationRelationship" id="8d84949c-da2f-456f-9c85-eb903765cea5" source="c69264a3-6790-4058-8056-d7654ae77a75" target="1480bf3c-d41d-4fea-827b-9ef9f79e6f49"/>
+    <element xsi:type="archimate:RealizationRelationship" id="65eeae27-537c-48c0-9390-455f475c2800" source="cfe6f942-99a2-4512-bf58-9be6921adb78" target="c69264a3-6790-4058-8056-d7654ae77a75"/>
+    <element xsi:type="archimate:RealizationRelationship" id="4d511da2-7df6-4beb-b47c-78b2f788e5f5" source="aae5673b-3220-4959-bd3b-a4351a94194d" target="5e3cba4d-6785-4a6a-80e7-ccabcb45c0e3"/>
+    <element xsi:type="archimate:RealizationRelationship" id="32f934ac-0d3b-43d1-9f47-447f6e564ba7" source="a46b13f6-899f-4651-bccd-67685ea0ab9d" target="2cc22b82-8760-46b4-80cb-118fb3cb04ee"/>
+    <element xsi:type="archimate:RealizationRelationship" id="0bef2725-e92f-4ade-887e-3bd76eab034c" source="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d" target="9dc22627-f969-46c8-ac76-9f1ac9b35767"/>
+    <element xsi:type="archimate:RealizationRelationship" id="fec9ce18-5dfb-4483-b947-1d4dd4709b45" source="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e" target="0984a188-6642-400c-a42f-20277624eee9"/>
+    <element xsi:type="archimate:RealizationRelationship" id="8d9b2549-3ec1-40a7-a2bf-709d6c667325" source="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe" target="83a086f5-68c0-475d-88e8-c53fc033a533"/>
+    <element xsi:type="archimate:RealizationRelationship" id="d965cc0d-8876-416d-a61a-e12259efd4f9" source="c2bcebbc-2082-490d-aa5f-8606e59e3833" target="b7b2aa18-f4d7-4341-945c-03837cb989a6"/>
+    <element xsi:type="archimate:RealizationRelationship" id="bf3a3e9b-d6d1-4989-8ef7-021d1f136913" source="ca49e61c-53cc-4599-b5fd-f30b80485328" target="7c846708-edd4-4a3a-afad-a711b21abeb4"/>
+    <element xsi:type="archimate:RealizationRelationship" id="caab7f6b-ecb8-4257-85ef-bbff50ef681b" source="68e59636-1f53-4336-9cfd-64fa6acae825" target="197d58a5-2131-41e0-8ec3-37bc46ed9b3d"/>
+    <element xsi:type="archimate:RealizationRelationship" id="e08143cb-a72b-4f01-b442-a8c905603be7" source="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349" target="5647d2da-812c-4a0f-af6e-bac94daa4aeb"/>
+    <element xsi:type="archimate:AggregationRelationship" id="82858c74-fa51-4408-a384-50f99602243a" source="efbf9f7a-7b30-462f-a471-3cc2049014b5" target="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349"/>
+    <element xsi:type="archimate:ServingRelationship" id="914b5bb1-2b50-4216-9c5a-9523b0195905" source="80a99a8e-fb62-4313-a07a-806f36458f24" target="850c5bb7-f0c1-45ba-871f-daa2fd9c4be3"/>
+    <element xsi:type="archimate:AssociationRelationship" name="issues" id="33c74883-5fc8-48e6-abc8-7c960abeb80c" source="80a99a8e-fb62-4313-a07a-806f36458f24" target="cf368aea-2632-472e-93fd-9283417f526a"/>
+    <element xsi:type="archimate:AssociationRelationship" name="has been issued a" id="c33cf13e-3c35-49a0-ac07-e06bef941711" source="850c5bb7-f0c1-45ba-871f-daa2fd9c4be3" target="cf368aea-2632-472e-93fd-9283417f526a"/>
+    <element xsi:type="archimate:AssociationRelationship" name="operates" id="d3fc5765-3740-46cf-9955-1f0f3517b9c6" source="cd190536-c093-4a49-99d6-a8cbb5de0876" target="807ead6b-5921-4901-85ba-5aec2455149c"/>
+    <element xsi:type="archimate:AssociationRelationship" name="has been issued a" id="4622db27-8f5e-4815-b434-d68e13d6fd4d" source="cd190536-c093-4a49-99d6-a8cbb5de0876" target="8fce2f71-c778-48e6-8182-fc92696647d7"/>
+    <element xsi:type="archimate:AssociationRelationship" name="issues" id="82553ea7-0ba8-4e81-a579-13e0bec64da9" source="80a99a8e-fb62-4313-a07a-806f36458f24" target="8fce2f71-c778-48e6-8182-fc92696647d7"/>
+    <element xsi:type="archimate:AggregationRelationship" id="90f0b202-39d7-4bf6-bedd-4c2d4d75451a" source="47712a4b-32c0-401d-887e-b659374a7166" target="8fce2f71-c778-48e6-8182-fc92696647d7"/>
+    <element xsi:type="archimate:AggregationRelationship" id="70325378-0b5d-491e-9467-3d31f6fb6da7" source="47712a4b-32c0-401d-887e-b659374a7166" target="cf368aea-2632-472e-93fd-9283417f526a"/>
+    <element xsi:type="archimate:CompositionRelationship" id="11ea2f70-8009-4b9d-b099-5e577fd85591" source="efbf9f7a-7b30-462f-a471-3cc2049014b5" target="d61e514e-6042-4efb-8e3a-ab4c7f021115"/>
+    <element xsi:type="archimate:AssociationRelationship" id="b773c016-9fae-4909-8927-39901fdfbb37" source="64672752-1b6b-4fd1-ab2f-9f8eff29d024" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
+    <element xsi:type="archimate:CompositionRelationship" id="a5bb98eb-6c1d-4921-a9c0-98c9aad8aad6" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="17bc30f6-6291-43bc-b2e5-ef5202bc18e4"/>
+    <element xsi:type="archimate:CompositionRelationship" id="e94b7f72-17c2-4873-b380-d13b4d41bac5" source="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac" target="819e7e8c-a185-4b7b-b205-940fefcfe408"/>
+    <element xsi:type="archimate:AssociationRelationship" id="89cb6502-27b4-4e3f-9003-025e782532c8" source="819e7e8c-a185-4b7b-b205-940fefcfe408" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
+    <element xsi:type="archimate:AssociationRelationship" id="7cc89761-4fb9-4a12-b8a3-a041f3e331cc" source="17bc30f6-6291-43bc-b2e5-ef5202bc18e4" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
+    <element xsi:type="archimate:CompositionRelationship" id="e8fa5e21-a7ef-40b0-90cb-01348f4baad2" source="46993d29-c622-4da9-a827-613b19e05632" target="ac982ce3-98bb-468b-a594-1f4463e9babb"/>
+    <element xsi:type="archimate:RealizationRelationship" id="1eee23ab-85d7-448b-b91d-57acde471992" source="46993d29-c622-4da9-a827-613b19e05632" target="c96b9e24-98ca-466d-a2d2-84993b348d01"/>
+    <element xsi:type="archimate:AccessRelationship" id="ac09f3a3-c4a9-4e2b-b82b-b65d12b43a24" source="ac982ce3-98bb-468b-a594-1f4463e9babb" target="013f493e-1497-459f-96e7-e31942157778" accessType="1"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="61b2b7b0-2c9d-4bc3-9c47-097ec9c630e4" source="40e6d34e-02c4-4b57-8af3-a3bfc8c89962" target="46993d29-c622-4da9-a827-613b19e05632"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="b750d5ac-710f-44b7-8821-bfdaa2f3ef44" source="807ead6b-5921-4901-85ba-5aec2455149c" target="5039ff23-50cf-45d4-adba-913033c25087"/>
+    <element xsi:type="archimate:ServingRelationship" id="f2903ebc-ce72-40b8-95f7-3c2c3f7392e6" source="c96b9e24-98ca-466d-a2d2-84993b348d01" target="5039ff23-50cf-45d4-adba-913033c25087"/>
+    <element xsi:type="archimate:AccessRelationship" id="cf8b7260-494b-471f-bfc1-b9e8189a6759" source="807ead6b-5921-4901-85ba-5aec2455149c" target="013f493e-1497-459f-96e7-e31942157778" accessType="1"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="72d95b66-6a86-46d0-b55a-c9c8fd549c31" source="807ead6b-5921-4901-85ba-5aec2455149c" target="f32e715b-c735-4cf9-95d5-442183d6a78e"/>
+    <element xsi:type="archimate:ServingRelationship" id="ecb67bbc-5c83-405a-8190-286df0169aa4" source="f32e715b-c735-4cf9-95d5-442183d6a78e" target="ff508064-92fe-4e22-af13-af192add8998"/>
+    <element xsi:type="archimate:AssignmentRelationship" id="fb759bf5-b9f2-485f-84ec-95a6478d9ddb" source="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" target="ff508064-92fe-4e22-af13-af192add8998"/>
+    <element xsi:type="archimate:AccessRelationship" id="90f3360e-3901-468f-b687-90a86c2ef36b" source="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" target="013f493e-1497-459f-96e7-e31942157778" accessType="1"/>
+    <element xsi:type="archimate:AccessRelationship" id="7f9a43c4-38c1-40ba-ada8-b1351ad5abf9" source="807ead6b-5921-4901-85ba-5aec2455149c" target="00da5f43-6209-4b90-98b6-66f241f28bc1"/>
+    <element xsi:type="archimate:AccessRelationship" id="687ed250-82b7-4953-b2b7-c9bb6da15ce6" source="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" target="00da5f43-6209-4b90-98b6-66f241f28bc1" accessType="1"/>
+    <element xsi:type="archimate:AssociationRelationship" name="sealed using" id="fb5fa28b-f3fb-4ec8-91f1-e34aba0e184c" source="00da5f43-6209-4b90-98b6-66f241f28bc1" target="013f493e-1497-459f-96e7-e31942157778"/>
+    <element xsi:type="archimate:AssociationRelationship" id="ab39ae42-6590-4c70-8d26-7393994c09ee" source="487a932a-1d31-45a6-83d3-4a9a28854c90" target="0de99420-0252-4788-8732-ee96f9f5e8b9"/>
+    <element xsi:type="archimate:AssociationRelationship" name="issues" id="3908b95a-ba84-4ac6-bb2f-6bb43280d875" source="80a99a8e-fb62-4313-a07a-806f36458f24" target="0de99420-0252-4788-8732-ee96f9f5e8b9"/>
+    <element xsi:type="archimate:AggregationRelationship" id="cd39cff2-f359-4c32-8d98-b9cd24e85278" source="47712a4b-32c0-401d-887e-b659374a7166" target="0de99420-0252-4788-8732-ee96f9f5e8b9"/>
+    <element xsi:type="archimate:AssociationRelationship" name="used for sealing" id="bdf4759c-2641-4287-90c3-a041ab95260d" source="c0b1a8e1-f208-4c52-ba6e-5b1831bd8ff8" target="1ff4e70e-c2a6-4571-b700-c56d647e574b"/>
+    <element xsi:type="archimate:AssociationRelationship" name="used for sealing" id="a2a116ac-b8af-4f25-a83d-846812131d6a" source="145becdc-6985-48c4-a520-a423ae80ec59" target="b05b5406-553d-4861-9f0d-9dfdce3907fc"/>
+    <element xsi:type="archimate:AssociationRelationship" name="encrypted using" id="643accf2-614c-4e47-924f-b988442de60e" source="145becdc-6985-48c4-a520-a423ae80ec59" target="1ff4e70e-c2a6-4571-b700-c56d647e574b"/>
+    <element xsi:type="archimate:AccessRelationship" id="10de0df5-0d04-4aa6-b193-6e395117585f" source="7c846708-edd4-4a3a-afad-a711b21abeb4" target="1ff4e70e-c2a6-4571-b700-c56d647e574b" accessType="1"/>
+    <element xsi:type="archimate:AccessRelationship" id="464c9909-07ca-414e-b01e-853fff1b4327" source="b7b2aa18-f4d7-4341-945c-03837cb989a6" target="1ff4e70e-c2a6-4571-b700-c56d647e574b"/>
+    <element xsi:type="archimate:AccessRelationship" id="313ced4f-857f-4427-b01d-52500abdd37d" source="7c846708-edd4-4a3a-afad-a711b21abeb4" target="b05b5406-553d-4861-9f0d-9dfdce3907fc"/>
+    <element xsi:type="archimate:AccessRelationship" id="5343b9e4-3bde-4405-bd5e-c9aee89f9406" source="b7b2aa18-f4d7-4341-945c-03837cb989a6" target="b05b5406-553d-4861-9f0d-9dfdce3907fc" accessType="1"/>
+    <element xsi:type="archimate:AggregationRelationship" id="571b3819-03f2-4bc1-83de-20730c99666d" source="108c2382-e2bf-4950-93ba-10e61c915592" target="145becdc-6985-48c4-a520-a423ae80ec59"/>
+  </folder>
+  <folder name="Views" id="6858a5da-9c29-42e4-b91f-7737960e8c81" type="diagrams">
+    <element xsi:type="archimate:ArchimateDiagramModel" name="DC process" id="b2d9e1fa-4c8b-4619-831c-344c1c691750" viewpoint="business_process_cooperation">
+      <child xsi:type="archimate:DiagramObject" id="a8c9c047-2870-4e3d-bb31-d47e6001937e" targetConnections="8920a3e0-9314-48c6-86fa-83af2dcb74ea" archimateElement="fad8e664-4fad-4d4a-9a10-74c710c3b97a">
+        <bounds x="717" y="48" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="0c33a8a1-d44d-494a-b128-3846af792c1d" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
+        <bounds x="61" y="203" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="f1abf54e-0289-4202-8ea7-c72315031dcc" source="0c33a8a1-d44d-494a-b128-3846af792c1d" target="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" archimateRelationship="04909a89-4d80-4f31-b9de-3d210fe7ed6c"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" targetConnections="f1abf54e-0289-4202-8ea7-c72315031dcc" archimateElement="0d63a4ac-c4aa-40ff-8653-14d682a5531f">
+        <bounds x="253" y="162" width="1036" height="137"/>
+        <sourceConnection xsi:type="archimate:Connection" id="35584f62-000c-436a-9390-3a6afe5475b1" source="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" target="f58321fb-461a-4b66-8cb0-d45dc732bb9c" archimateRelationship="46975254-c3e9-4883-8aa3-3169ed3d7c29"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8920a3e0-9314-48c6-86fa-83af2dcb74ea" source="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" target="a8c9c047-2870-4e3d-bb31-d47e6001937e" archimateRelationship="743fde0d-4f10-435e-b6ea-04be25793ed4"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ff002975-2b9b-4281-a03c-947fb6b247ee" source="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" target="f6851ebd-cdca-4298-8b94-069d9a770ea4" archimateRelationship="7247a8bd-1ef3-469b-a1ba-f1a7b7b52bb1"/>
+        <sourceConnection xsi:type="archimate:Connection" id="82ec3b58-4528-4a80-add3-7c16c1ac48c7" source="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" target="adcc048e-87bd-4248-b0db-749f59b875ab" archimateRelationship="7e54ed44-7028-4eae-bb37-e4d806adce10"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ce6033ee-3f07-4e5b-9844-f490686e3893" source="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" target="7097cc42-aafc-4a1d-94a6-0f36d5dccefb" archimateRelationship="a9b35bc6-28cd-43e7-8e11-f2a7f7717f59"/>
+        <child xsi:type="archimate:DiagramObject" id="f58321fb-461a-4b66-8cb0-d45dc732bb9c" targetConnections="35584f62-000c-436a-9390-3a6afe5475b1 616c7337-615a-4232-9c0e-253b69af550c" archimateElement="445db22c-cb8a-48ea-81c6-dbc99399fa91">
+          <bounds x="438" y="48" width="163" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="6431677a-a431-4c53-8ff0-8d601599384f" source="f58321fb-461a-4b66-8cb0-d45dc732bb9c" target="6f836328-6a05-4af8-8ac4-d88583b17fc5" archimateRelationship="e90bbf63-7edb-421c-b6c8-2f694dc54642"/>
+          <sourceConnection xsi:type="archimate:Connection" id="d33f983c-0489-4aaa-9492-3bad10f8e706" source="f58321fb-461a-4b66-8cb0-d45dc732bb9c" target="bc498011-2866-4ffb-9c63-93efa1fa47c3" archimateRelationship="ebaeef97-a5a7-4a12-9300-5385ee892937"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="6f836328-6a05-4af8-8ac4-d88583b17fc5" targetConnections="6431677a-a431-4c53-8ff0-8d601599384f" archimateElement="38b61099-7009-443e-b2df-761194403fc9">
+          <bounds x="630" y="68" width="15" height="15"/>
+          <sourceConnection xsi:type="archimate:Connection" id="37d85466-1037-4d76-bee5-ebc33d2d2566" source="6f836328-6a05-4af8-8ac4-d88583b17fc5" target="f6851ebd-cdca-4298-8b94-069d9a770ea4" archimateRelationship="5ce00bed-a816-46ec-852c-8b08ffd09313"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a938843e-c6f7-45b1-8bbe-e3e72dbd2a82" source="6f836328-6a05-4af8-8ac4-d88583b17fc5" target="bfcef93d-60f6-487e-bf92-df52c278dce7" archimateRelationship="ff5a9d5f-d965-4e18-9cff-c0585ea91588">
+            <bendpoint startY="47" endX="-204" endY="47"/>
+            <bendpoint startX="204" startY="46" endY="46"/>
+          </sourceConnection>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="f6851ebd-cdca-4298-8b94-069d9a770ea4" targetConnections="ff002975-2b9b-4281-a03c-947fb6b247ee 37d85466-1037-4d76-bee5-ebc33d2d2566" archimateElement="542c9c45-139b-415b-9888-5dbbb4bb03ff">
+          <bounds x="663" y="48" width="145" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="0de004fb-2718-4139-9f81-1ad7f5e51e59" source="f6851ebd-cdca-4298-8b94-069d9a770ea4" target="bfcef93d-60f6-487e-bf92-df52c278dce7" archimateRelationship="5205c941-97bc-4e24-99a5-6ef8e130b32e"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b4e135a1-4cbc-4346-8d23-a55ca5385bb8" source="f6851ebd-cdca-4298-8b94-069d9a770ea4" target="6a80cbf8-9525-45f4-88a9-e664348af26f" archimateRelationship="61bca2c7-2f9f-4dbc-836c-9161369dd62d"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="bfcef93d-60f6-487e-bf92-df52c278dce7" targetConnections="0de004fb-2718-4139-9f81-1ad7f5e51e59 a938843e-c6f7-45b1-8bbe-e3e72dbd2a82" archimateElement="d4fc0cff-64bd-47c2-be39-0d20e234a2dd">
+          <bounds x="834" y="68" width="15" height="15"/>
+          <sourceConnection xsi:type="archimate:Connection" id="5aae7440-e6c6-4acf-b4cb-6d096deea80c" source="bfcef93d-60f6-487e-bf92-df52c278dce7" target="adcc048e-87bd-4248-b0db-749f59b875ab" archimateRelationship="775b4d4c-00cc-422d-bac0-1cda4fd75754"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="adcc048e-87bd-4248-b0db-749f59b875ab" targetConnections="82ec3b58-4528-4a80-add3-7c16c1ac48c7 5aae7440-e6c6-4acf-b4cb-6d096deea80c" archimateElement="6bc58486-8d4c-49ae-acf9-5113c4688d0a">
+          <bounds x="870" y="48" width="145" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="16e086bb-7aca-4026-9eb0-3907fdd2a160" source="adcc048e-87bd-4248-b0db-749f59b875ab" target="95982d01-b463-4201-b028-693a6aeaf7c3" archimateRelationship="43f0f298-99a7-41e5-b998-5ae8ae89e0ca"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="716c0b59-751e-4cfc-814d-698180ff7c05" archimateElement="5711d3c1-4238-4c90-af05-6238458b576b">
+          <bounds x="24" y="48" width="169" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="409f6278-dea6-49b0-bcde-f28ca241c0ae" source="716c0b59-751e-4cfc-814d-698180ff7c05" target="7097cc42-aafc-4a1d-94a6-0f36d5dccefb" archimateRelationship="77260656-6e53-49a3-ba8b-50950c55b2e9"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="7097cc42-aafc-4a1d-94a6-0f36d5dccefb" targetConnections="ce6033ee-3f07-4e5b-9844-f490686e3893 409f6278-dea6-49b0-bcde-f28ca241c0ae" archimateElement="9c559689-3063-4980-ba54-6c6571fdfafa">
+          <bounds x="264" y="48" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="616c7337-615a-4232-9c0e-253b69af550c" source="7097cc42-aafc-4a1d-94a6-0f36d5dccefb" target="f58321fb-461a-4b66-8cb0-d45dc732bb9c" archimateRelationship="85a1d04f-8d78-45c3-96af-7eb8da2de5bb"/>
+          <sourceConnection xsi:type="archimate:Connection" id="ee4dada7-3241-48d4-a119-bd05a72e51f7" source="7097cc42-aafc-4a1d-94a6-0f36d5dccefb" target="7d082516-21c5-4c88-ac21-31203e5cb42c" archimateRelationship="d5e09a47-9af8-40b6-b997-b8d222fbd40c"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="bc498011-2866-4ffb-9c63-93efa1fa47c3" targetConnections="d33f983c-0489-4aaa-9492-3bad10f8e706 ab2bca2f-4ae6-45f6-b307-763edad1e90c" archimateElement="53ac573b-bada-4a1a-8eb5-debaa24d3809">
+        <bounds x="717" y="340" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="6a80cbf8-9525-45f4-88a9-e664348af26f" targetConnections="b4e135a1-4cbc-4346-8d23-a55ca5385bb8 75c7f933-7f06-4363-af75-98440d25c502" archimateElement="95d4f54d-d61a-494e-9ae7-f04687e1e0f7">
+        <bounds x="933" y="340" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="7d082516-21c5-4c88-ac21-31203e5cb42c" targetConnections="ee4dada7-3241-48d4-a119-bd05a72e51f7 09ef7818-9242-4f80-a96f-3bc444fbf641" archimateElement="030bea1c-c47c-49f8-89d6-8cd8d8929cf8">
+        <bounds x="517" y="340" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="95982d01-b463-4201-b028-693a6aeaf7c3" targetConnections="16e086bb-7aca-4026-9eb0-3907fdd2a160" archimateElement="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508">
+        <bounds x="1141" y="340" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="75c7f933-7f06-4363-af75-98440d25c502" source="95982d01-b463-4201-b028-693a6aeaf7c3" target="6a80cbf8-9525-45f4-88a9-e664348af26f" archimateRelationship="c576ed23-6c2d-41e8-9c2b-b70f55934df1"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ab2bca2f-4ae6-45f6-b307-763edad1e90c" source="95982d01-b463-4201-b028-693a6aeaf7c3" target="bc498011-2866-4ffb-9c63-93efa1fa47c3" archimateRelationship="259a3bae-99c7-4af9-8754-aa31175d39db">
+          <bendpoint startX="-46" startY="53" endX="378" endY="53"/>
+          <bendpoint startX="-388" startY="50" endX="36" endY="50"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="09ef7818-9242-4f80-a96f-3bc444fbf641" source="95982d01-b463-4201-b028-693a6aeaf7c3" target="7d082516-21c5-4c88-ac21-31203e5cb42c" archimateRelationship="72639f88-abea-4c10-bbbe-f33e1209959c">
+          <bendpoint startX="-29" startY="64" endX="595" endY="64"/>
+          <bendpoint startX="-586" startY="61" endX="38" endY="61"/>
+        </sourceConnection>
+      </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Using eDelivery for information exchange" id="a8345071-4aee-4bf1-bb65-64a973ab97ad" viewpoint="business_process_cooperation">
+      <child xsi:type="archimate:DiagramObject" id="185d2b7a-83f3-473d-b3bf-a6f15fde82d3" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
+        <bounds x="98" y="235" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="75f88a3b-ec74-4447-9516-84a692c1e299" source="185d2b7a-83f3-473d-b3bf-a6f15fde82d3" target="7b4d2585-5d09-4360-9be0-fca3e6fabe64" archimateRelationship="04909a89-4d80-4f31-b9de-3d210fe7ed6c"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="b04dad77-d0a8-423e-a6c1-7764441c0c29" archimateElement="8a97d09b-a4db-47f1-bf36-d3dc84e0f234">
+        <bounds x="971" y="235" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="87969801-ebf8-4b9a-a4f7-db6150920d0a" source="b04dad77-d0a8-423e-a6c1-7764441c0c29" target="b48ce86b-9329-4663-aa7f-4dd0c5f0eae5" archimateRelationship="7226f430-eda2-4e1e-bf19-3a9117613bb5"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="7b4d2585-5d09-4360-9be0-fca3e6fabe64" targetConnections="75f88a3b-ec74-4447-9516-84a692c1e299" archimateElement="0d63a4ac-c4aa-40ff-8653-14d682a5531f">
+        <bounds x="271" y="200" width="183" height="125"/>
+        <sourceConnection xsi:type="archimate:Connection" id="fe0c3a8c-3650-4075-b464-512eaf888371" source="7b4d2585-5d09-4360-9be0-fca3e6fabe64" target="2e29ebe8-caf6-4bca-8790-bc83a6c9ba37" archimateRelationship="743fde0d-4f10-435e-b6ea-04be25793ed4"/>
+        <sourceConnection xsi:type="archimate:Connection" id="fe91a7fe-3f0e-46f3-bc16-5ca2550c3537" source="7b4d2585-5d09-4360-9be0-fca3e6fabe64" target="cac15b12-8181-4416-a7c9-774f3ef09b89" archimateRelationship="7e54ed44-7028-4eae-bb37-e4d806adce10"/>
+        <child xsi:type="archimate:DiagramObject" id="cac15b12-8181-4416-a7c9-774f3ef09b89" targetConnections="fe91a7fe-3f0e-46f3-bc16-5ca2550c3537 f28e0db0-c114-4166-afef-9da4a1d70ecd" archimateElement="6bc58486-8d4c-49ae-acf9-5113c4688d0a">
+          <bounds x="33" y="34" width="120" height="69"/>
+          <sourceConnection xsi:type="archimate:Connection" id="2fde208a-302a-4006-b03f-779d9d0c770b" source="cac15b12-8181-4416-a7c9-774f3ef09b89" target="c03abb1e-d906-43f3-913d-a61c53f1e8e1" archimateRelationship="43f0f298-99a7-41e5-b998-5ae8ae89e0ca"/>
+          <sourceConnection xsi:type="archimate:Connection" id="4db8fc2d-ee86-4e08-834a-fe5c2776b1b6" source="cac15b12-8181-4416-a7c9-774f3ef09b89" target="9772fa1f-e140-425f-a589-8db14763ca8b" archimateRelationship="0be45e23-ff6e-4fb1-9de3-8d85cee0ba19"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="2e29ebe8-caf6-4bca-8790-bc83a6c9ba37" targetConnections="fe0c3a8c-3650-4075-b464-512eaf888371" archimateElement="fad8e664-4fad-4d4a-9a10-74c710c3b97a">
+        <bounds x="299" y="125" width="127" height="40"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="9772fa1f-e140-425f-a589-8db14763ca8b" targetConnections="daf64682-62b9-43c5-bd7c-3b43018f40ad 4db8fc2d-ee86-4e08-834a-fe5c2776b1b6" archimateElement="ef17e0d7-bed7-4f7f-8462-f4d07d2a2d69">
+        <bounds x="271" y="364" width="183" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="f28e0db0-c114-4166-afef-9da4a1d70ecd" source="9772fa1f-e140-425f-a589-8db14763ca8b" target="cac15b12-8181-4416-a7c9-774f3ef09b89" archimateRelationship="dd8cdaff-6f27-499c-b3a6-2078e3aa3b9c">
+          <bendpoint startX="14" startY="-73" endX="12" endY="50"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="e8623290-0d76-4b5d-b7ee-440591976447" source="9772fa1f-e140-425f-a589-8db14763ca8b" target="bce3a8a5-0d7c-463f-aba8-c9b2f2a3af8f" archimateRelationship="8c213188-eec1-4a90-8dcd-a42383a94e38"/>
+        <sourceConnection xsi:type="archimate:Connection" id="44b52bb1-1795-44e4-9baa-2514178eda53" source="9772fa1f-e140-425f-a589-8db14763ca8b" target="a4528e90-f493-474d-94bc-ec951cb5a7e8" archimateRelationship="3af58bef-a455-47b9-8aae-b838767f6614">
+          <bendpoint startX="228" startY="14" endX="-232" endY="14"/>
+        </sourceConnection>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="e5cb9837-f4fb-4a53-9d6a-08d60ae029db" archimateElement="95eb3e6f-f928-49ae-8c1e-008b3a677158">
+        <bounds x="98" y="364" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="daf64682-62b9-43c5-bd7c-3b43018f40ad" source="e5cb9837-f4fb-4a53-9d6a-08d60ae029db" target="9772fa1f-e140-425f-a589-8db14763ca8b" archimateRelationship="c9e10f16-7115-4cbe-9752-1a5cd6d6996d"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="c03abb1e-d906-43f3-913d-a61c53f1e8e1" targetConnections="2fde208a-302a-4006-b03f-779d9d0c770b 7b7bba32-e3af-400b-942b-81fd1795c4af 91ac6ae2-f53d-429e-ba0e-474950d70b15" archimateElement="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508">
+        <bounds x="538" y="235" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="a4528e90-f493-474d-94bc-ec951cb5a7e8" targetConnections="93d1f16a-f040-492c-bec5-75a26eec9357 44b52bb1-1795-44e4-9baa-2514178eda53" archimateElement="12b4c919-6fb8-4009-a99b-306bbb3cf5dd">
+        <bounds x="731" y="364" width="183" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="a0020a4f-276a-4a66-9c0a-5d20394d3b19" source="a4528e90-f493-474d-94bc-ec951cb5a7e8" target="bce3a8a5-0d7c-463f-aba8-c9b2f2a3af8f" archimateRelationship="120dd2f9-7cd5-4b9e-a58b-7054bd65a052"/>
+        <sourceConnection xsi:type="archimate:Connection" id="2882b8c4-d0ff-496c-9699-8bb7d8b12051" source="a4528e90-f493-474d-94bc-ec951cb5a7e8" target="b48ce86b-9329-4663-aa7f-4dd0c5f0eae5" archimateRelationship="72eeaacb-7f3c-4419-b196-770252a0777e"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5f102412-7204-4b6d-bd58-8b3e27d7a9f3" source="a4528e90-f493-474d-94bc-ec951cb5a7e8" target="b48ce86b-9329-4663-aa7f-4dd0c5f0eae5" archimateRelationship="0008c8e1-fda3-458b-bd9b-a9a56468a258">
+          <bendpoint startX="-18" startY="-31" endX="-19" endY="98"/>
+        </sourceConnection>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="cae85ecc-0d7b-47f4-94e1-0f3e2bbc1d35" archimateElement="95b78242-cd23-445d-af51-41409c4f20c6">
+        <bounds x="971" y="364" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="93d1f16a-f040-492c-bec5-75a26eec9357" source="cae85ecc-0d7b-47f4-94e1-0f3e2bbc1d35" target="a4528e90-f493-474d-94bc-ec951cb5a7e8" archimateRelationship="f9423481-da51-43ab-b957-72d82a037631"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="b48ce86b-9329-4663-aa7f-4dd0c5f0eae5" targetConnections="87969801-ebf8-4b9a-a4f7-db6150920d0a 2882b8c4-d0ff-496c-9699-8bb7d8b12051 5f102412-7204-4b6d-bd58-8b3e27d7a9f3" archimateElement="a2307ac8-440f-4e9d-94ec-310d20b36df8">
+        <bounds x="733" y="200" width="181" height="125"/>
+        <sourceConnection xsi:type="archimate:Connection" id="91ac6ae2-f53d-429e-ba0e-474950d70b15" source="b48ce86b-9329-4663-aa7f-4dd0c5f0eae5" target="c03abb1e-d906-43f3-913d-a61c53f1e8e1" archimateRelationship="4646b9a5-e538-4964-87b4-ff32fa20fa01"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="bce3a8a5-0d7c-463f-aba8-c9b2f2a3af8f" targetConnections="e8623290-0d76-4b5d-b7ee-440591976447 a0020a4f-276a-4a66-9c0a-5d20394d3b19" archimateElement="40566433-b208-4b0b-ab2f-ac56863fa713">
+        <bounds x="538" y="364" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="7b7bba32-e3af-400b-942b-81fd1795c4af" source="bce3a8a5-0d7c-463f-aba8-c9b2f2a3af8f" target="c03abb1e-d906-43f3-913d-a61c53f1e8e1" archimateRelationship="96ba3f91-051d-47bc-9dde-03e4431135a3"/>
+      </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Information exchange between DC and DP " id="742e250d-a03d-4c13-97a6-80790e7d8df1" viewpoint="business_process_cooperation">
+      <child xsi:type="archimate:DiagramObject" id="f7fb7040-0fa6-4bde-901e-f536a2c0ff2f" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
+        <bounds x="312" y="88" width="183" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="17c3d972-3067-4682-9fe7-eff33a03247e" source="f7fb7040-0fa6-4bde-901e-f536a2c0ff2f" target="0bb11302-0a53-4caf-967f-f138b6d97171" archimateRelationship="04909a89-4d80-4f31-b9de-3d210fe7ed6c"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="abe8e512-507e-4c71-9ea9-f0c99b1f0051" archimateElement="8a97d09b-a4db-47f1-bf36-d3dc84e0f234">
+        <bounds x="851" y="88" width="181" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="c8ee1e2f-e82f-4990-b949-e6044f82b241" source="abe8e512-507e-4c71-9ea9-f0c99b1f0051" target="97aa03b2-d11a-4f55-a323-45601a61c374" archimateRelationship="7226f430-eda2-4e1e-bf19-3a9117613bb5"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="0bb11302-0a53-4caf-967f-f138b6d97171" targetConnections="17c3d972-3067-4682-9fe7-eff33a03247e" archimateElement="0d63a4ac-c4aa-40ff-8653-14d682a5531f">
+        <bounds x="312" y="200" width="183" height="285"/>
+        <sourceConnection xsi:type="archimate:Connection" id="7b65d482-4f2e-49b7-86f5-c9fe5442fe85" source="0bb11302-0a53-4caf-967f-f138b6d97171" target="c70480e1-1481-448b-af61-81f6207f1e74" archimateRelationship="743fde0d-4f10-435e-b6ea-04be25793ed4"/>
+        <sourceConnection xsi:type="archimate:Connection" id="6a71c168-3fa2-4b1c-8a60-406442451b71" source="0bb11302-0a53-4caf-967f-f138b6d97171" target="bd5b56e9-a8c0-40bd-9c4b-a742b2cb939c" archimateRelationship="7e54ed44-7028-4eae-bb37-e4d806adce10"/>
+        <sourceConnection xsi:type="archimate:Connection" id="f589f250-26c5-4c80-84fb-4a0ef4145861" source="0bb11302-0a53-4caf-967f-f138b6d97171" target="30774cc5-fd5d-4d2f-bccd-94b8a39278e6" archimateRelationship="1b62e40b-6cce-4920-b99c-cb53245bebc6"/>
+        <child xsi:type="archimate:DiagramObject" id="bd5b56e9-a8c0-40bd-9c4b-a742b2cb939c" targetConnections="6a71c168-3fa2-4b1c-8a60-406442451b71 4a92d48a-ed46-4dd1-b9f0-f5c3a4ae7913" archimateElement="6bc58486-8d4c-49ae-acf9-5113c4688d0a">
+          <bounds x="33" y="127" width="120" height="69"/>
+          <sourceConnection xsi:type="archimate:Connection" id="924466e0-bfb3-48b9-9378-9c5875564b6c" source="bd5b56e9-a8c0-40bd-9c4b-a742b2cb939c" target="66c7117f-6bb2-416c-bcab-1191963873c9" archimateRelationship="43f0f298-99a7-41e5-b998-5ae8ae89e0ca"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="56fa6fd4-2812-4ec3-b2bb-8268535dc0b6" archimateElement="5711d3c1-4238-4c90-af05-6238458b576b">
+          <bounds x="33" y="32" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="4a92d48a-ed46-4dd1-b9f0-f5c3a4ae7913" source="56fa6fd4-2812-4ec3-b2bb-8268535dc0b6" target="bd5b56e9-a8c0-40bd-9c4b-a742b2cb939c" archimateRelationship="c7a4cf3e-b1b4-40bd-8879-3f5d7ef45d37"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="c70480e1-1481-448b-af61-81f6207f1e74" targetConnections="7b65d482-4f2e-49b7-86f5-c9fe5442fe85" archimateElement="fad8e664-4fad-4d4a-9a10-74c710c3b97a">
+        <bounds x="142" y="200" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="66c7117f-6bb2-416c-bcab-1191963873c9" targetConnections="924466e0-bfb3-48b9-9378-9c5875564b6c 5fbd8547-1373-4dd6-9565-930f3f3b3d72" archimateElement="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508">
+        <bounds x="613" y="340" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="980e6505-0bbe-4bc0-a790-544ebaaf48dd" source="66c7117f-6bb2-416c-bcab-1191963873c9" target="f48780f7-0444-4304-ad63-58e805af0d55" archimateRelationship="72639f88-abea-4c10-bbbe-f33e1209959c"/>
+        <sourceConnection xsi:type="archimate:Connection" id="939d3a41-7403-4106-bc35-97cf067d34dd" source="66c7117f-6bb2-416c-bcab-1191963873c9" target="827e2a84-2a86-4058-ae84-b7def5d5e841" archimateRelationship="c576ed23-6c2d-41e8-9c2b-b70f55934df1"/>
+        <sourceConnection xsi:type="archimate:Connection" id="11b6ec0c-a073-4ab3-b3c9-a4db3fb461df" source="66c7117f-6bb2-416c-bcab-1191963873c9" target="43741519-153c-4a34-b74b-9a544b7361f7" archimateRelationship="259a3bae-99c7-4af9-8754-aa31175d39db"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="97aa03b2-d11a-4f55-a323-45601a61c374" targetConnections="c8ee1e2f-e82f-4990-b949-e6044f82b241" archimateElement="a2307ac8-440f-4e9d-94ec-310d20b36df8">
+        <bounds x="851" y="200" width="181" height="285"/>
+        <sourceConnection xsi:type="archimate:Connection" id="f593ab23-0533-4e6e-8e4f-7024072e2e69" source="97aa03b2-d11a-4f55-a323-45601a61c374" target="bb2d3009-f380-4eb0-be94-e455e711ca05" archimateRelationship="bc0c881b-2587-4c7d-820f-99ab59a701b4"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5fa20f66-185e-43f8-9981-edfaad61bef0" source="97aa03b2-d11a-4f55-a323-45601a61c374" target="fb3ed460-f6af-4eed-893f-cb9850282eff" archimateRelationship="9d9dca79-9456-48e7-99b0-e6401a71d55d"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5fbd8547-1373-4dd6-9565-930f3f3b3d72" source="97aa03b2-d11a-4f55-a323-45601a61c374" target="66c7117f-6bb2-416c-bcab-1191963873c9" archimateRelationship="4646b9a5-e538-4964-87b4-ff32fa20fa01"/>
+        <child xsi:type="archimate:DiagramObject" id="bb2d3009-f380-4eb0-be94-e455e711ca05" targetConnections="f593ab23-0533-4e6e-8e4f-7024072e2e69" archimateElement="52a66463-82a1-4de1-8405-57da30cbfd3b">
+          <bounds x="35" y="135" width="120" height="55"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="fb3ed460-f6af-4eed-893f-cb9850282eff" targetConnections="5fa20f66-185e-43f8-9981-edfaad61bef0" archimateElement="c89398a3-0a96-4369-a8c0-b7fbbccf232c">
+          <bounds x="35" y="214" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="46407acf-595f-49ea-9ed2-0d509f7c780b" source="fb3ed460-f6af-4eed-893f-cb9850282eff" target="30774cc5-fd5d-4d2f-bccd-94b8a39278e6" archimateRelationship="e0ac69dc-fcd3-4ec6-9f11-14490b4acf63"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="f48780f7-0444-4304-ad63-58e805af0d55" targetConnections="980e6505-0bbe-4bc0-a790-544ebaaf48dd" archimateElement="030bea1c-c47c-49f8-89d6-8cd8d8929cf8">
+        <bounds x="520" y="261" width="94" height="44"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="827e2a84-2a86-4058-ae84-b7def5d5e841" targetConnections="939d3a41-7403-4106-bc35-97cf067d34dd" archimateElement="95d4f54d-d61a-494e-9ae7-f04687e1e0f7">
+        <bounds x="732" y="261" width="94" height="44"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="43741519-153c-4a34-b74b-9a544b7361f7" targetConnections="11b6ec0c-a073-4ab3-b3c9-a4db3fb461df" archimateElement="53ac573b-bada-4a1a-8eb5-debaa24d3809">
+        <bounds x="626" y="261" width="94" height="44"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="30774cc5-fd5d-4d2f-bccd-94b8a39278e6" targetConnections="46407acf-595f-49ea-9ed2-0d509f7c780b f589f250-26c5-4c80-84fb-4a0ef4145861" archimateElement="1b0685dc-27ec-49a5-8dad-448356ff10ef">
+        <bounds x="613" y="418" width="120" height="55"/>
+      </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Complete process between DC and DP (vertical)" id="5524a28e-6215-4397-b607-ad6437677c9d" viewpoint="business_process_cooperation">
+      <child xsi:type="archimate:DiagramObject" id="3a01ed09-0aa0-428f-9e3d-91a524f425df" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
+        <bounds x="312" y="120" width="183" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="7d9faf8c-e68a-46ad-a703-2b742f1da061" source="3a01ed09-0aa0-428f-9e3d-91a524f425df" target="bd03eb18-6582-4620-ae0b-caef394f18b0" archimateRelationship="04909a89-4d80-4f31-b9de-3d210fe7ed6c"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="aed2e0a1-ee98-47bd-a48f-203f0fcf3c84" archimateElement="8a97d09b-a4db-47f1-bf36-d3dc84e0f234">
+        <bounds x="851" y="120" width="181" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="1f8a6507-6a55-49ab-b7d0-9aa8f6e6250b" source="aed2e0a1-ee98-47bd-a48f-203f0fcf3c84" target="6308026a-b919-481c-bb9b-092eab5a3f01" archimateRelationship="7226f430-eda2-4e1e-bf19-3a9117613bb5"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="bd03eb18-6582-4620-ae0b-caef394f18b0" targetConnections="7d9faf8c-e68a-46ad-a703-2b742f1da061" archimateElement="0d63a4ac-c4aa-40ff-8653-14d682a5531f">
+        <bounds x="312" y="200" width="183" height="569"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ea3aa038-afaa-40b3-aa1d-61c7c6f40222" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="d88bba15-37e1-4572-9b91-8cea4d110af2" archimateRelationship="743fde0d-4f10-435e-b6ea-04be25793ed4"/>
+        <sourceConnection xsi:type="archimate:Connection" id="eb3875bb-4a9e-4e02-b76a-1e3fe0b9ccc6" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="75212b3e-0299-4e45-a8b1-0edc41c8266e" archimateRelationship="7e54ed44-7028-4eae-bb37-e4d806adce10"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ac9d6cb3-78d7-4786-a94d-085bab079ed0" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="734ddcf5-7cb1-4f6f-a2b6-f1536118d586" archimateRelationship="1b62e40b-6cce-4920-b99c-cb53245bebc6"/>
+        <sourceConnection xsi:type="archimate:Connection" id="555e930f-4a89-46fe-a553-e8b47cacff7c" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="89bb1927-54a9-47cf-9ed1-ca54fdf60ee3" archimateRelationship="a9b35bc6-28cd-43e7-8e11-f2a7f7717f59"/>
+        <sourceConnection xsi:type="archimate:Connection" id="484d41ae-8fcb-4d5d-95ca-a2fe93d829ed" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="b974fe82-d084-4f1b-98e2-eec06a0ab2eb" archimateRelationship="46975254-c3e9-4883-8aa3-3169ed3d7c29"/>
+        <sourceConnection xsi:type="archimate:Connection" id="efa1c3c6-a408-4ba0-8548-ffdb97edba4d" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="34b44261-6050-4b81-9ced-78bdb1a5d0ec" archimateRelationship="7247a8bd-1ef3-469b-a1ba-f1a7b7b52bb1"/>
+        <child xsi:type="archimate:DiagramObject" id="75212b3e-0299-4e45-a8b1-0edc41c8266e" targetConnections="eb3875bb-4a9e-4e02-b76a-1e3fe0b9ccc6 2cada7fe-7a14-43e5-acf1-7f90eabb6cf6" archimateElement="6bc58486-8d4c-49ae-acf9-5113c4688d0a">
+          <bounds x="33" y="347" width="120" height="69"/>
+          <sourceConnection xsi:type="archimate:Connection" id="39377a93-cc2e-4649-8ee0-9bb6600fe8ca" source="75212b3e-0299-4e45-a8b1-0edc41c8266e" target="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" archimateRelationship="43f0f298-99a7-41e5-b998-5ae8ae89e0ca"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="c8325022-38d5-4ddb-838a-adb685fae637" archimateElement="5711d3c1-4238-4c90-af05-6238458b576b">
+          <bounds x="33" y="32" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="8b11c7bb-6705-4ef3-8f0a-70578bbc2b6e" source="c8325022-38d5-4ddb-838a-adb685fae637" target="89bb1927-54a9-47cf-9ed1-ca54fdf60ee3" archimateRelationship="77260656-6e53-49a3-ba8b-50950c55b2e9"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="89bb1927-54a9-47cf-9ed1-ca54fdf60ee3" targetConnections="555e930f-4a89-46fe-a553-e8b47cacff7c 8b11c7bb-6705-4ef3-8f0a-70578bbc2b6e" archimateElement="9c559689-3063-4980-ba54-6c6571fdfafa">
+          <bounds x="33" y="120" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="ab001448-8009-4983-b3a3-4d010ad9a5d4" source="89bb1927-54a9-47cf-9ed1-ca54fdf60ee3" target="1cb1894c-21aa-4696-b983-f05ddcc9d7c9" archimateRelationship="d5e09a47-9af8-40b6-b997-b8d222fbd40c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="f8a2a98b-cd51-4d29-a824-9c9e04d74b2d" source="89bb1927-54a9-47cf-9ed1-ca54fdf60ee3" target="b974fe82-d084-4f1b-98e2-eec06a0ab2eb" archimateRelationship="85a1d04f-8d78-45c3-96af-7eb8da2de5bb"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="b974fe82-d084-4f1b-98e2-eec06a0ab2eb" targetConnections="484d41ae-8fcb-4d5d-95ca-a2fe93d829ed f8a2a98b-cd51-4d29-a824-9c9e04d74b2d" archimateElement="445db22c-cb8a-48ea-81c6-dbc99399fa91">
+          <bounds x="33" y="194" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="00c6d7b1-a89f-4059-a2e4-4944765f3d06" source="b974fe82-d084-4f1b-98e2-eec06a0ab2eb" target="ad4510ee-c8c0-483f-9a23-3405f1f24c68" archimateRelationship="ebaeef97-a5a7-4a12-9300-5385ee892937"/>
+          <sourceConnection xsi:type="archimate:Connection" id="0672b06a-6e8b-47b5-afef-430e1ab4eb9a" source="b974fe82-d084-4f1b-98e2-eec06a0ab2eb" target="34b44261-6050-4b81-9ced-78bdb1a5d0ec" archimateRelationship="3c4793d1-7323-442f-82b1-b8df2d720110"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="34b44261-6050-4b81-9ced-78bdb1a5d0ec" targetConnections="efa1c3c6-a408-4ba0-8548-ffdb97edba4d 0672b06a-6e8b-47b5-afef-430e1ab4eb9a" archimateElement="542c9c45-139b-415b-9888-5dbbb4bb03ff">
+          <bounds x="33" y="269" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="64b8476e-ebce-4b0d-8917-d1aab3ea7f43" source="34b44261-6050-4b81-9ced-78bdb1a5d0ec" target="0686b730-66fc-4264-8f8e-d7fef064cc28" archimateRelationship="61bca2c7-2f9f-4dbc-836c-9161369dd62d"/>
+          <sourceConnection xsi:type="archimate:Connection" id="2cada7fe-7a14-43e5-acf1-7f90eabb6cf6" source="34b44261-6050-4b81-9ced-78bdb1a5d0ec" target="75212b3e-0299-4e45-a8b1-0edc41c8266e" archimateRelationship="1a6c5e38-43e7-421d-8b88-000ad22bea39"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="d88bba15-37e1-4572-9b91-8cea4d110af2" targetConnections="ea3aa038-afaa-40b3-aa1d-61c7c6f40222" archimateElement="fad8e664-4fad-4d4a-9a10-74c710c3b97a">
+        <bounds x="142" y="200" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" targetConnections="39377a93-cc2e-4649-8ee0-9bb6600fe8ca 66bf98d7-bab5-4bc2-ad8e-791eddf1c57c" archimateElement="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508">
+        <bounds x="613" y="554" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="55f42732-70ab-4067-8ac3-7a507b4f28d5" source="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" target="1cb1894c-21aa-4696-b983-f05ddcc9d7c9" archimateRelationship="72639f88-abea-4c10-bbbe-f33e1209959c">
+          <bendpoint startX="-106" startY="-54" endY="193"/>
+          <bendpoint startX="-106" startY="-125" endY="122"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="d868be14-bd34-4fa1-93ea-f6fdc296ff41" source="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" target="0686b730-66fc-4264-8f8e-d7fef064cc28" archimateRelationship="c576ed23-6c2d-41e8-9c2b-b70f55934df1"/>
+        <sourceConnection xsi:type="archimate:Connection" id="36a7e9d6-53eb-4aa1-b48d-28cfa3cf3466" source="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" target="ad4510ee-c8c0-483f-9a23-3405f1f24c68" archimateRelationship="259a3bae-99c7-4af9-8754-aa31175d39db"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="6308026a-b919-481c-bb9b-092eab5a3f01" targetConnections="1f8a6507-6a55-49ab-b7d0-9aa8f6e6250b" archimateElement="a2307ac8-440f-4e9d-94ec-310d20b36df8">
+        <bounds x="851" y="200" width="181" height="569"/>
+        <sourceConnection xsi:type="archimate:Connection" id="a9e2f15f-5224-40e4-8812-23247a298c99" source="6308026a-b919-481c-bb9b-092eab5a3f01" target="ef95e097-8130-46df-9a05-7da4ba5ea6c1" archimateRelationship="bc0c881b-2587-4c7d-820f-99ab59a701b4"/>
+        <sourceConnection xsi:type="archimate:Connection" id="cd4beb20-0e10-4ad8-ae9a-3f8b6d00d865" source="6308026a-b919-481c-bb9b-092eab5a3f01" target="da7b2934-576f-4655-9163-281ebc85f711" archimateRelationship="9d9dca79-9456-48e7-99b0-e6401a71d55d"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8aa63e9d-c9b6-4694-911a-7a7fb5448451" source="6308026a-b919-481c-bb9b-092eab5a3f01" target="d09d9132-d1c0-4907-8489-3ec119a85f34" archimateRelationship="8f45d271-86d5-4609-95cc-008e96b631e0"/>
+        <sourceConnection xsi:type="archimate:Connection" id="66bf98d7-bab5-4bc2-ad8e-791eddf1c57c" source="6308026a-b919-481c-bb9b-092eab5a3f01" target="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" archimateRelationship="4646b9a5-e538-4964-87b4-ff32fa20fa01"/>
+        <child xsi:type="archimate:DiagramObject" id="ef95e097-8130-46df-9a05-7da4ba5ea6c1" targetConnections="a9e2f15f-5224-40e4-8812-23247a298c99" archimateElement="52a66463-82a1-4de1-8405-57da30cbfd3b">
+          <bounds x="35" y="352" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="d8745083-f16e-4ca2-a3a9-d79abf52de9e" source="ef95e097-8130-46df-9a05-7da4ba5ea6c1" target="d09d9132-d1c0-4907-8489-3ec119a85f34" archimateRelationship="7f81d755-9b4d-4232-8557-3cefe31f5e0d"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="da7b2934-576f-4655-9163-281ebc85f711" targetConnections="cd4beb20-0e10-4ad8-ae9a-3f8b6d00d865 a1b7fdca-e2a1-47a1-a4a1-fa81df5eedda" archimateElement="c89398a3-0a96-4369-a8c0-b7fbbccf232c">
+          <bounds x="35" y="505" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="4b8b8458-24e3-4d64-833b-3580dd2da83a" source="da7b2934-576f-4655-9163-281ebc85f711" target="734ddcf5-7cb1-4f6f-a2b6-f1536118d586" archimateRelationship="e0ac69dc-fcd3-4ec6-9f11-14490b4acf63"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="d09d9132-d1c0-4907-8489-3ec119a85f34" targetConnections="8aa63e9d-c9b6-4694-911a-7a7fb5448451 d8745083-f16e-4ca2-a3a9-d79abf52de9e" archimateElement="727c636e-94a8-4af8-9af6-04bcec1e3143">
+          <bounds x="35" y="428" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a1b7fdca-e2a1-47a1-a4a1-fa81df5eedda" source="d09d9132-d1c0-4907-8489-3ec119a85f34" target="da7b2934-576f-4655-9163-281ebc85f711" archimateRelationship="c00dabfa-1e04-4dd3-b160-d62a1bbf9237"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="1cb1894c-21aa-4696-b983-f05ddcc9d7c9" targetConnections="55f42732-70ab-4067-8ac3-7a507b4f28d5 ab001448-8009-4983-b3a3-4d010ad9a5d4" archimateElement="030bea1c-c47c-49f8-89d6-8cd8d8929cf8">
+        <bounds x="520" y="326" width="94" height="44"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="0686b730-66fc-4264-8f8e-d7fef064cc28" targetConnections="d868be14-bd34-4fa1-93ea-f6fdc296ff41 64b8476e-ebce-4b0d-8917-d1aab3ea7f43" archimateElement="95d4f54d-d61a-494e-9ae7-f04687e1e0f7">
+        <bounds x="732" y="472" width="94" height="44"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="ad4510ee-c8c0-483f-9a23-3405f1f24c68" targetConnections="36a7e9d6-53eb-4aa1-b48d-28cfa3cf3466 00c6d7b1-a89f-4059-a2e4-4944765f3d06" archimateElement="53ac573b-bada-4a1a-8eb5-debaa24d3809">
+        <bounds x="626" y="402" width="94" height="44"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="734ddcf5-7cb1-4f6f-a2b6-f1536118d586" targetConnections="ac9d6cb3-78d7-4786-a94d-085bab079ed0 4b8b8458-24e3-4d64-833b-3580dd2da83a" archimateElement="1b0685dc-27ec-49a5-8dad-448356ff10ef">
+        <bounds x="613" y="705" width="120" height="55"/>
+      </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Complete process between DC and DP (horizontal)" id="15f55112-e64e-4680-a0f6-2696a20eaf0a" viewpoint="business_process_cooperation">
+      <child xsi:type="archimate:DiagramObject" id="7f2cdae5-bff1-4066-bc0a-c782b12157de" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
+        <bounds x="79" y="192" width="183" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="19ba4494-c7d3-4729-9362-031587780cce" source="7f2cdae5-bff1-4066-bc0a-c782b12157de" target="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" archimateRelationship="04909a89-4d80-4f31-b9de-3d210fe7ed6c"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="c8bfbe15-fc95-4f35-80c6-59b99ba59bfd" archimateElement="8a97d09b-a4db-47f1-bf36-d3dc84e0f234">
+        <bounds x="80" y="518" width="181" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="af394d1d-d551-4231-b74d-07b8dfcd3954" source="c8bfbe15-fc95-4f35-80c6-59b99ba59bfd" target="702d5f62-6ead-4612-ab4c-159cf1ace010" archimateRelationship="7226f430-eda2-4e1e-bf19-3a9117613bb5"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" targetConnections="19ba4494-c7d3-4729-9362-031587780cce" archimateElement="0d63a4ac-c4aa-40ff-8653-14d682a5531f">
+        <bounds x="318" y="174" width="962" height="179"/>
+        <sourceConnection xsi:type="archimate:Connection" id="6e0d849b-6f8d-42a7-a121-15a2d8dc14ee" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="4b423323-d871-466c-9ccb-10d0bd5aad29" archimateRelationship="743fde0d-4f10-435e-b6ea-04be25793ed4"/>
+        <sourceConnection xsi:type="archimate:Connection" id="a6ea6fa4-57da-4e8b-989b-bf8148dda12c" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="aa91b9ac-8844-4a7a-8683-c46c32c49e10" archimateRelationship="7e54ed44-7028-4eae-bb37-e4d806adce10"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e5b451b4-0361-4053-8fd0-4ff56007a572" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="eb8fcc2e-c4c6-4ea2-9efc-ffc4dc7c1ab5" archimateRelationship="1b62e40b-6cce-4920-b99c-cb53245bebc6"/>
+        <sourceConnection xsi:type="archimate:Connection" id="0f11d79b-aae6-4999-bab4-13c4cc60ce5c" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="2f0b3a80-f2c2-4f61-ac70-d1a42bc7f21e" archimateRelationship="a9b35bc6-28cd-43e7-8e11-f2a7f7717f59"/>
+        <sourceConnection xsi:type="archimate:Connection" id="6b5a8ece-3435-45d3-9ee7-d4fbb96948ee" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="85c47833-52a2-45cd-a517-cf28b62d20d8" archimateRelationship="46975254-c3e9-4883-8aa3-3169ed3d7c29"/>
+        <sourceConnection xsi:type="archimate:Connection" id="38c76484-ab24-4ae2-a4c6-174ca0799695" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="c3bce02f-1811-48b2-840c-1f3ce72521fc" archimateRelationship="7247a8bd-1ef3-469b-a1ba-f1a7b7b52bb1"/>
+        <child xsi:type="archimate:DiagramObject" id="aa91b9ac-8844-4a7a-8683-c46c32c49e10" targetConnections="a6ea6fa4-57da-4e8b-989b-bf8148dda12c bebfbeb0-3405-4bab-82b3-4309b7f4f026" archimateElement="6bc58486-8d4c-49ae-acf9-5113c4688d0a">
+          <bounds x="659" y="32" width="156" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="788f2cf3-aad3-4bc3-8245-bc0037e442da" source="aa91b9ac-8844-4a7a-8683-c46c32c49e10" target="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" archimateRelationship="43f0f298-99a7-41e5-b998-5ae8ae89e0ca"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="57579fb1-2154-47b6-844c-c38e68725177" archimateElement="5711d3c1-4238-4c90-af05-6238458b576b">
+          <bounds x="33" y="32" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="e3a4c652-37ed-4034-b15d-3704645c42c8" source="57579fb1-2154-47b6-844c-c38e68725177" target="2f0b3a80-f2c2-4f61-ac70-d1a42bc7f21e" archimateRelationship="77260656-6e53-49a3-ba8b-50950c55b2e9"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="2f0b3a80-f2c2-4f61-ac70-d1a42bc7f21e" targetConnections="0f11d79b-aae6-4999-bab4-13c4cc60ce5c e3a4c652-37ed-4034-b15d-3704645c42c8" archimateElement="9c559689-3063-4980-ba54-6c6571fdfafa">
+          <bounds x="193" y="32" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="d51be25a-db87-4045-bc1f-44f70588796b" source="2f0b3a80-f2c2-4f61-ac70-d1a42bc7f21e" target="79da122f-e446-49e4-bcc4-2b3872153db5" archimateRelationship="d5e09a47-9af8-40b6-b997-b8d222fbd40c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="e99d3006-1d19-409c-a738-8c7a3917bf26" source="2f0b3a80-f2c2-4f61-ac70-d1a42bc7f21e" target="85c47833-52a2-45cd-a517-cf28b62d20d8" archimateRelationship="85a1d04f-8d78-45c3-96af-7eb8da2de5bb"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="85c47833-52a2-45cd-a517-cf28b62d20d8" targetConnections="6b5a8ece-3435-45d3-9ee7-d4fbb96948ee e99d3006-1d19-409c-a738-8c7a3917bf26" archimateElement="445db22c-cb8a-48ea-81c6-dbc99399fa91">
+          <bounds x="348" y="32" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a7e58d3d-de2a-464b-8290-420389de9925" source="85c47833-52a2-45cd-a517-cf28b62d20d8" target="75bb5413-c260-43f1-9735-90fd46f2ba78" archimateRelationship="ebaeef97-a5a7-4a12-9300-5385ee892937"/>
+          <sourceConnection xsi:type="archimate:Connection" id="7bb54f81-fe19-4a2f-956a-cf4d7d0307b9" source="85c47833-52a2-45cd-a517-cf28b62d20d8" target="c3bce02f-1811-48b2-840c-1f3ce72521fc" archimateRelationship="3c4793d1-7323-442f-82b1-b8df2d720110"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="c3bce02f-1811-48b2-840c-1f3ce72521fc" targetConnections="38c76484-ab24-4ae2-a4c6-174ca0799695 7bb54f81-fe19-4a2f-956a-cf4d7d0307b9" archimateElement="542c9c45-139b-415b-9888-5dbbb4bb03ff">
+          <bounds x="501" y="32" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="f784f3b4-dbc5-480d-a92b-07b13624d061" source="c3bce02f-1811-48b2-840c-1f3ce72521fc" target="7f4a81a1-d4d5-4a7d-93c2-92e36b4b9187" archimateRelationship="61bca2c7-2f9f-4dbc-836c-9161369dd62d"/>
+          <sourceConnection xsi:type="archimate:Connection" id="bebfbeb0-3405-4bab-82b3-4309b7f4f026" source="c3bce02f-1811-48b2-840c-1f3ce72521fc" target="aa91b9ac-8844-4a7a-8683-c46c32c49e10" archimateRelationship="1a6c5e38-43e7-421d-8b88-000ad22bea39"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="79da122f-e446-49e4-bcc4-2b3872153db5" targetConnections="d51be25a-db87-4045-bc1f-44f70588796b 0b8381bc-5729-4555-841a-e40ebac436e1" archimateElement="030bea1c-c47c-49f8-89d6-8cd8d8929cf8">
+          <bounds x="206" y="123" width="94" height="44"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="75bb5413-c260-43f1-9735-90fd46f2ba78" targetConnections="a7e58d3d-de2a-464b-8290-420389de9925 ffe20d3a-11ea-4ed6-aab0-c9bb9e990453" archimateElement="53ac573b-bada-4a1a-8eb5-debaa24d3809">
+          <bounds x="361" y="123" width="94" height="44"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="7f4a81a1-d4d5-4a7d-93c2-92e36b4b9187" targetConnections="f784f3b4-dbc5-480d-a92b-07b13624d061 85bd79ac-4d34-43fc-b95e-a2e0a44ed583" archimateElement="95d4f54d-d61a-494e-9ae7-f04687e1e0f7">
+          <bounds x="514" y="123" width="94" height="44"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="4b423323-d871-466c-9ccb-10d0bd5aad29" targetConnections="6e0d849b-6f8d-42a7-a121-15a2d8dc14ee" archimateElement="fad8e664-4fad-4d4a-9a10-74c710c3b97a">
+        <bounds x="344" y="81" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="702d5f62-6ead-4612-ab4c-159cf1ace010" targetConnections="af394d1d-d551-4231-b74d-07b8dfcd3954" archimateElement="a2307ac8-440f-4e9d-94ec-310d20b36df8">
+        <bounds x="318" y="481" width="962" height="130"/>
+        <sourceConnection xsi:type="archimate:Connection" id="2b9d9f62-f8ad-407b-b6f4-46487dc8fdef" source="702d5f62-6ead-4612-ab4c-159cf1ace010" target="2c9376d3-71cc-42f0-922d-25744c5a9545" archimateRelationship="bc0c881b-2587-4c7d-820f-99ab59a701b4"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8326543d-d50b-41b7-9533-1a33be08feb7" source="702d5f62-6ead-4612-ab4c-159cf1ace010" target="7b383d01-f8b8-4e4e-a730-54e7b5c88b85" archimateRelationship="9d9dca79-9456-48e7-99b0-e6401a71d55d"/>
+        <sourceConnection xsi:type="archimate:Connection" id="2b2277e4-87fe-42d7-b1b3-5f8ebed59738" source="702d5f62-6ead-4612-ab4c-159cf1ace010" target="2b28c958-6f3b-43e2-8c45-28fa0da43c6e" archimateRelationship="8f45d271-86d5-4609-95cc-008e96b631e0"/>
+        <sourceConnection xsi:type="archimate:Connection" id="dc3162a3-6003-4204-ad10-ef1d4305d36c" source="702d5f62-6ead-4612-ab4c-159cf1ace010" target="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" archimateRelationship="4646b9a5-e538-4964-87b4-ff32fa20fa01"/>
+        <child xsi:type="archimate:DiagramObject" id="2c9376d3-71cc-42f0-922d-25744c5a9545" targetConnections="2b9d9f62-f8ad-407b-b6f4-46487dc8fdef" archimateElement="52a66463-82a1-4de1-8405-57da30cbfd3b">
+          <bounds x="489" y="43" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b27e4411-41af-46f8-9609-2d49b5ba3c75" source="2c9376d3-71cc-42f0-922d-25744c5a9545" target="2b28c958-6f3b-43e2-8c45-28fa0da43c6e" archimateRelationship="7f81d755-9b4d-4232-8557-3cefe31f5e0d"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="7b383d01-f8b8-4e4e-a730-54e7b5c88b85" targetConnections="8326543d-d50b-41b7-9533-1a33be08feb7 b17b4724-23e5-4a8a-8fa2-53ea871d89de" archimateElement="c89398a3-0a96-4369-a8c0-b7fbbccf232c">
+          <bounds x="823" y="43" width="126" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="45d9fbed-c157-46bf-b696-61c77afc341c" source="7b383d01-f8b8-4e4e-a730-54e7b5c88b85" target="eb8fcc2e-c4c6-4ea2-9efc-ffc4dc7c1ab5" archimateRelationship="e0ac69dc-fcd3-4ec6-9f11-14490b4acf63"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="2b28c958-6f3b-43e2-8c45-28fa0da43c6e" targetConnections="2b2277e4-87fe-42d7-b1b3-5f8ebed59738 b27e4411-41af-46f8-9609-2d49b5ba3c75" archimateElement="727c636e-94a8-4af8-9af6-04bcec1e3143">
+          <bounds x="661" y="43" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b17b4724-23e5-4a8a-8fa2-53ea871d89de" source="2b28c958-6f3b-43e2-8c45-28fa0da43c6e" target="7b383d01-f8b8-4e4e-a730-54e7b5c88b85" archimateRelationship="c00dabfa-1e04-4dd3-b160-d62a1bbf9237"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="eb8fcc2e-c4c6-4ea2-9efc-ffc4dc7c1ab5" targetConnections="e5b451b4-0361-4053-8fd0-4ff56007a572 45d9fbed-c157-46bf-b696-61c77afc341c" archimateElement="1b0685dc-27ec-49a5-8dad-448356ff10ef">
+        <bounds x="1143" y="387" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" targetConnections="788f2cf3-aad3-4bc3-8245-bc0037e442da dc3162a3-6003-4204-ad10-ef1d4305d36c" archimateElement="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508">
+        <bounds x="984" y="387" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="0b8381bc-5729-4555-841a-e40ebac436e1" source="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" target="79da122f-e446-49e4-bcc4-2b3872153db5" archimateRelationship="72639f88-abea-4c10-bbbe-f33e1209959c">
+          <bendpoint startX="-453" startY="12" endX="26" endY="107"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="85bd79ac-4d34-43fc-b95e-a2e0a44ed583" source="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" target="7f4a81a1-d4d5-4a7d-93c2-92e36b4b9187" archimateRelationship="c576ed23-6c2d-41e8-9c2b-b70f55934df1">
+          <bendpoint startX="-136" startY="-17" endX="35" endY="78"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="ffe20d3a-11ea-4ed6-aab0-c9bb9e990453" source="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" target="75bb5413-c260-43f1-9735-90fd46f2ba78" archimateRelationship="259a3bae-99c7-4af9-8754-aa31175d39db">
+          <bendpoint startX="-296" startY="-2" endX="28" endY="93"/>
+        </sourceConnection>
+      </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="End-to-end trust" id="2ef0f1e6-ed46-4fb8-8e3f-90f368511740" viewpoint="application_usage">
+      <child xsi:type="archimate:DiagramObject" id="656726a8-f365-4470-90b0-681b7b8c8aed" targetConnections="dfb60f62-f03f-4839-86d5-4f9d6279a4c5" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
+        <bounds x="282" y="113" width="179" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="c9f5891a-0c4a-43db-af17-8b2e893e3ab0" source="656726a8-f365-4470-90b0-681b7b8c8aed" target="238c5933-96e4-427c-96ab-2ee787142be8" archimateRelationship="e1e988a6-73c8-4563-8cee-37fa9b8017d1"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="0ec10b84-302d-4127-b068-9351e929ccad" targetConnections="bfa7ada6-f7ae-4905-9987-dc912459ca0d" archimateElement="8a97d09b-a4db-47f1-bf36-d3dc84e0f234">
+        <bounds x="746" y="113" width="179" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="3e879451-42ef-4541-bb3b-a16a21995bd7" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75">
+        <bounds x="282" y="240" width="179" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="dfb60f62-f03f-4839-86d5-4f9d6279a4c5" source="3e879451-42ef-4541-bb3b-a16a21995bd7" target="656726a8-f365-4470-90b0-681b7b8c8aed" archimateRelationship="ba2b56e1-2552-4374-96d4-99eed3ead52b"/>
+        <sourceConnection xsi:type="archimate:Connection" id="09bac615-6a05-48bc-9dc8-53330e2c7e38" source="3e879451-42ef-4541-bb3b-a16a21995bd7" target="80569f59-bebd-4861-82a3-45cd4b967bf7" archimateRelationship="40e2396d-2bc8-4117-9fcd-c7b661f834b6"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="510d5f98-62b1-42d2-bdd4-c1848ea67af9" archimateElement="0984a188-6642-400c-a42f-20277624eee9">
+        <bounds x="746" y="240" width="179" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="bfa7ada6-f7ae-4905-9987-dc912459ca0d" source="510d5f98-62b1-42d2-bdd4-c1848ea67af9" target="0ec10b84-302d-4127-b068-9351e929ccad" archimateRelationship="61505492-a12a-41d8-a385-6141c37992e7"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ed18d3ee-3289-4fa6-8994-a96bb385528b" source="510d5f98-62b1-42d2-bdd4-c1848ea67af9" target="c8bc4235-91a6-4cfd-ab08-6e5f515d9221" archimateRelationship="7d6df378-e814-49f3-91e5-cbf1f9042af9"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="238c5933-96e4-427c-96ab-2ee787142be8" targetConnections="c9f5891a-0c4a-43db-af17-8b2e893e3ab0 2782568e-8b66-4465-a5df-dff3cf70075c 4a81412a-ca7b-431a-8c29-386765244016" archimateElement="8c13ed65-5ac1-4785-aed2-0ad35e10e96e">
+        <bounds x="537" y="240" width="143" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8536d6da-a308-4849-babd-ff6281c41d7f" source="238c5933-96e4-427c-96ab-2ee787142be8" target="cbb27895-6153-4816-9cc4-d15a597e6a80" archimateRelationship="3ed190cb-3ea5-4d07-9c1a-01125aae0908"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="cbb27895-6153-4816-9cc4-d15a597e6a80" targetConnections="e7397a03-fd68-4b3b-935a-5ee4ab9349fa 4283cd6f-cd35-4794-874f-053d0cbf5fe1 8536d6da-a308-4849-babd-ff6281c41d7f" archimateElement="c950ad79-d64f-44de-96f5-c8c2e5567fd1">
+        <bounds x="537" y="353" width="143" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="80569f59-bebd-4861-82a3-45cd4b967bf7" targetConnections="09bac615-6a05-48bc-9dc8-53330e2c7e38" archimateElement="e7bc1ccd-f2c9-4d69-a857-72a1056a19e7">
+        <bounds x="282" y="353" width="179" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e7397a03-fd68-4b3b-935a-5ee4ab9349fa" source="80569f59-bebd-4861-82a3-45cd4b967bf7" target="cbb27895-6153-4816-9cc4-d15a597e6a80" archimateRelationship="39d64881-7f81-467e-975c-4298a395051d"/>
+        <sourceConnection xsi:type="archimate:Connection" id="4a81412a-ca7b-431a-8c29-386765244016" source="80569f59-bebd-4861-82a3-45cd4b967bf7" target="238c5933-96e4-427c-96ab-2ee787142be8" archimateRelationship="aea5772d-9e38-45b2-a1b3-0e63bbe875ef"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="c8bc4235-91a6-4cfd-ab08-6e5f515d9221" targetConnections="ed18d3ee-3289-4fa6-8994-a96bb385528b" archimateElement="ebe8815f-5659-458b-be8d-65ac0baf21c2">
+        <bounds x="746" y="353" width="179" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="4283cd6f-cd35-4794-874f-053d0cbf5fe1" source="c8bc4235-91a6-4cfd-ab08-6e5f515d9221" target="cbb27895-6153-4816-9cc4-d15a597e6a80" archimateRelationship="8dcae5d1-d852-4d66-8c74-4cc311a49dfd"/>
+        <sourceConnection xsi:type="archimate:Connection" id="2782568e-8b66-4465-a5df-dff3cf70075c" source="c8bc4235-91a6-4cfd-ab08-6e5f515d9221" target="238c5933-96e4-427c-96ab-2ee787142be8" archimateRelationship="92a66d4a-1b5a-4d61-b4d2-dd37d5d00a3c"/>
+      </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Brokered trust through gateways" id="99500a9d-2ccd-467b-8840-9f64c673390b" viewpoint="application_usage">
+      <child xsi:type="archimate:DiagramObject" id="5d952d0e-6060-460e-a9b4-c34f73747c22" targetConnections="25cff960-a5c0-4302-a0b0-ed14b3f5728d" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
+        <bounds x="123" y="87" width="144" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="6266dfc3-1244-40b0-a650-e1b3480d9987" targetConnections="66ddd2b6-88fc-4cda-9341-c12956fe12a5" archimateElement="8a97d09b-a4db-47f1-bf36-d3dc84e0f234">
+        <bounds x="983" y="87" width="144" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="636d5c0b-de77-445f-b88f-4a4e695bb1c3" targetConnections="c65ad902-2cf7-4869-9674-c7a87fd54fc3" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75">
+        <bounds x="325" y="87" width="179" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="25cff960-a5c0-4302-a0b0-ed14b3f5728d" source="636d5c0b-de77-445f-b88f-4a4e695bb1c3" target="5d952d0e-6060-460e-a9b4-c34f73747c22" archimateRelationship="ba2b56e1-2552-4374-96d4-99eed3ead52b"/>
+        <sourceConnection xsi:type="archimate:Connection" id="03ef9214-1696-43a8-9fdd-6a2c78fa02ba" source="636d5c0b-de77-445f-b88f-4a4e695bb1c3" target="179df9ac-094a-469a-85f0-2795a530db9a" archimateRelationship="1dbd287d-01da-4eba-9d63-20abfc405a33"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="66b90034-affb-42c3-be56-527ddd19b0db" targetConnections="562fb2ab-414e-4771-b10b-e98038645eac" archimateElement="0984a188-6642-400c-a42f-20277624eee9">
+        <bounds x="753" y="87" width="179" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="66ddd2b6-88fc-4cda-9341-c12956fe12a5" source="66b90034-affb-42c3-be56-527ddd19b0db" target="6266dfc3-1244-40b0-a650-e1b3480d9987" archimateRelationship="61505492-a12a-41d8-a385-6141c37992e7"/>
+        <sourceConnection xsi:type="archimate:Connection" id="221c7260-ec51-41da-81ac-9b96501259e0" source="66b90034-affb-42c3-be56-527ddd19b0db" target="179df9ac-094a-469a-85f0-2795a530db9a" archimateRelationship="c649fa7f-0a20-43ce-b1ec-a0b4bb39a5e7"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="179df9ac-094a-469a-85f0-2795a530db9a" targetConnections="03ef9214-1696-43a8-9fdd-6a2c78fa02ba 221c7260-ec51-41da-81ac-9b96501259e0 f00ec8ca-547b-4e82-8e0e-34789826e471" archimateElement="c950ad79-d64f-44de-96f5-c8c2e5567fd1">
+        <bounds x="559" y="87" width="140" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="c118c94a-92ec-421a-b326-5be8c71c9f0f" targetConnections="05d3ce3c-562f-4eea-aea3-87293f54835a" archimateElement="95eb3e6f-f928-49ae-8c1e-008b3a677158">
+        <bounds x="125" y="198" width="144" height="262"/>
+        <sourceConnection xsi:type="archimate:Connection" id="31295ac5-0aa1-4217-a98a-cc3353996530" source="c118c94a-92ec-421a-b326-5be8c71c9f0f" target="155ab06b-7b6e-477d-9448-9dbb557d88c1" archimateRelationship="b76f75f6-e675-49a7-b393-b0c619a31eca">
+          <bendpoint startX="47" startY="158" endX="-385" endY="55"/>
+          <bendpoint startX="392" startY="158" endX="-40" endY="55"/>
+        </sourceConnection>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="b7e33c90-f51d-4304-932b-a774d6808530" archimateElement="840d39d9-5dbd-485f-aecf-6a54b9185760">
+        <bounds x="326" y="316" width="178" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="d650f321-ef52-410e-8d88-dc4527d9d837" source="b7e33c90-f51d-4304-932b-a774d6808530" target="59bb7af5-7936-401c-a279-0ab3373fdcd1" archimateRelationship="a6a1675b-1183-4308-86e7-176a7a1c38d4"/>
+        <sourceConnection xsi:type="archimate:Connection" id="c38a0a21-1992-4e32-8e00-680a7e51b5fb" source="b7e33c90-f51d-4304-932b-a774d6808530" target="88167dd6-663a-4bd9-a512-d75a74392154" archimateRelationship="c1b032d3-c50d-4ed6-a101-e4e03879c74b"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8b9e542a-2bb6-4579-aedf-b1115601c57e" source="b7e33c90-f51d-4304-932b-a774d6808530" target="a8bb6f0a-74e8-4724-942d-a3604270566a" archimateRelationship="873d928f-fae0-48e8-92c6-c9b08b331775"/>
+        <sourceConnection xsi:type="archimate:Connection" id="05d3ce3c-562f-4eea-aea3-87293f54835a" source="b7e33c90-f51d-4304-932b-a774d6808530" target="c118c94a-92ec-421a-b326-5be8c71c9f0f" archimateRelationship="7d371c26-b1db-47ae-acce-6300aa44dd6b"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="a8bb6f0a-74e8-4724-942d-a3604270566a" targetConnections="8b9e542a-2bb6-4579-aedf-b1115601c57e 0b4728c1-dfa9-4612-9860-44673b8c1c0e 554cafa3-26fc-4526-9034-7c4b53968f3c" archimateElement="1ff4e70e-c2a6-4571-b700-c56d647e574b">
+        <bounds x="559" y="316" width="140" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="f00ec8ca-547b-4e82-8e0e-34789826e471" source="a8bb6f0a-74e8-4724-942d-a3604270566a" target="179df9ac-094a-469a-85f0-2795a530db9a" archimateRelationship="c14f095b-81e3-4f6a-9ee5-001b7b4e21a3"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="59bb7af5-7936-401c-a279-0ab3373fdcd1" targetConnections="d650f321-ef52-410e-8d88-dc4527d9d837" archimateElement="c04d706c-fba8-492c-a0d1-55f187cef654">
+        <bounds x="326" y="198" width="178" height="81"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ba13b3d9-95f9-45dd-88f8-34a226eefba5" source="59bb7af5-7936-401c-a279-0ab3373fdcd1" target="a5d6ad7c-0325-421d-8ae3-f974bfc4d542" archimateRelationship="f5979514-73cb-4fec-933b-e5c0c08eb348"/>
+        <sourceConnection xsi:type="archimate:Connection" id="c65ad902-2cf7-4869-9674-c7a87fd54fc3" source="59bb7af5-7936-401c-a279-0ab3373fdcd1" target="636d5c0b-de77-445f-b88f-4a4e695bb1c3" archimateRelationship="e8194e02-47ed-4782-840b-f301f26b9e57"/>
+        <child xsi:type="archimate:DiagramObject" id="a5d6ad7c-0325-421d-8ae3-f974bfc4d542" targetConnections="ba13b3d9-95f9-45dd-88f8-34a226eefba5" archimateElement="111e43d6-e4e3-4c68-a8b7-3abc8ef38cfa">
+          <bounds x="22" y="31" width="135" height="42"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="155ab06b-7b6e-477d-9448-9dbb557d88c1" targetConnections="0c45708a-6478-4b42-8f59-4a4d094c95d3 8492770b-54c3-4a2a-aa74-62d31e44546c 31295ac5-0aa1-4217-a98a-cc3353996530" archimateElement="0de99420-0252-4788-8732-ee96f9f5e8b9">
+        <bounds x="559" y="405" width="140" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="0b4728c1-dfa9-4612-9860-44673b8c1c0e" source="155ab06b-7b6e-477d-9448-9dbb557d88c1" target="a8bb6f0a-74e8-4724-942d-a3604270566a" archimateRelationship="25d43edc-de81-45a6-8c74-479a4d3894f9"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="88167dd6-663a-4bd9-a512-d75a74392154" targetConnections="c38a0a21-1992-4e32-8e00-680a7e51b5fb" archimateElement="d60feff7-3cf7-4158-9daa-f55098646351">
+        <bounds x="326" y="405" width="178" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="0c45708a-6478-4b42-8f59-4a4d094c95d3" source="88167dd6-663a-4bd9-a512-d75a74392154" target="155ab06b-7b6e-477d-9448-9dbb557d88c1" archimateRelationship="e14c0b3b-6f53-4a7f-86b4-5ece2e19d297"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="b3e7fea1-440a-4325-ada0-c70b28205d8e" archimateElement="83a924b3-9966-43f7-a838-87760185a97e">
+        <bounds x="754" y="316" width="178" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="58cf37be-345f-49f3-8920-4612cc57e5da" source="b3e7fea1-440a-4325-ada0-c70b28205d8e" target="543f1781-0035-47a5-8664-a6839cc9431c" archimateRelationship="61bad181-0237-4bae-af98-0cb28e29a757"/>
+        <sourceConnection xsi:type="archimate:Connection" id="86bd0bb6-5768-4f2d-830c-a30bc4e9849c" source="b3e7fea1-440a-4325-ada0-c70b28205d8e" target="534d2cb1-7bd3-4179-8b21-b70f283b9f58" archimateRelationship="233acd57-bae1-4da8-affb-f861254c2cb6"/>
+        <sourceConnection xsi:type="archimate:Connection" id="554cafa3-26fc-4526-9034-7c4b53968f3c" source="b3e7fea1-440a-4325-ada0-c70b28205d8e" target="a8bb6f0a-74e8-4724-942d-a3604270566a" archimateRelationship="2324f816-d7aa-4ae5-b233-6ec580157784"/>
+        <sourceConnection xsi:type="archimate:Connection" id="6adf47cd-3b23-45f7-81ec-75fab50acd2f" source="b3e7fea1-440a-4325-ada0-c70b28205d8e" target="847d939c-30a4-49f3-bf63-ce16a52e5610" archimateRelationship="4ffb4c4f-dd99-4ce1-878f-5d2b51132ce3"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="543f1781-0035-47a5-8664-a6839cc9431c" targetConnections="58cf37be-345f-49f3-8920-4612cc57e5da" archimateElement="dccb663c-584f-44ac-8d1e-e3d126f79772">
+        <bounds x="754" y="405" width="178" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8492770b-54c3-4a2a-aa74-62d31e44546c" source="543f1781-0035-47a5-8664-a6839cc9431c" target="155ab06b-7b6e-477d-9448-9dbb557d88c1" archimateRelationship="c3950612-5080-4d28-b276-2cec37cd5b2c"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="847d939c-30a4-49f3-bf63-ce16a52e5610" targetConnections="6adf47cd-3b23-45f7-81ec-75fab50acd2f" archimateElement="fca5d997-034e-454b-bb0f-195a06ff0053">
+        <bounds x="754" y="190" width="178" height="81"/>
+        <sourceConnection xsi:type="archimate:Connection" id="f8dc986d-bab2-4cdf-a1c1-284dfb67bd65" source="847d939c-30a4-49f3-bf63-ce16a52e5610" target="aef22720-6d86-470d-8578-3bee1a0544b0" archimateRelationship="fdbefc6e-6ab9-4cce-bee2-307bb69486e2"/>
+        <sourceConnection xsi:type="archimate:Connection" id="562fb2ab-414e-4771-b10b-e98038645eac" source="847d939c-30a4-49f3-bf63-ce16a52e5610" target="66b90034-affb-42c3-be56-527ddd19b0db" archimateRelationship="4504f86c-17f7-4b9b-93a8-81363473e011"/>
+        <child xsi:type="archimate:DiagramObject" id="aef22720-6d86-470d-8578-3bee1a0544b0" targetConnections="f8dc986d-bab2-4cdf-a1c1-284dfb67bd65" archimateElement="58f40f88-a7c0-466f-bcff-f088a7ae2879">
+          <bounds x="22" y="31" width="135" height="42"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="534d2cb1-7bd3-4179-8b21-b70f283b9f58" targetConnections="86bd0bb6-5768-4f2d-830c-a30bc4e9849c" archimateElement="95b78242-cd23-445d-af51-41409c4f20c6">
+        <bounds x="983" y="190" width="144" height="270"/>
+      </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Network overview" id="058dc34b-a0a0-40a5-811c-14efd43946c7">
+      <child xsi:type="archimate:DiagramObject" id="e8f44bd4-7b09-4e93-97a4-0461a4cf4f02" textPosition="2" archimateElement="efbf9f7a-7b30-462f-a471-3cc2049014b5">
+        <bounds x="756" y="288" width="684" height="132"/>
+        <sourceConnection xsi:type="archimate:Connection" id="2b68c129-195b-4830-a01a-0bfacd71b030" source="e8f44bd4-7b09-4e93-97a4-0461a4cf4f02" target="e9187ff9-d1a5-4c91-95c8-4d93d63c055e" archimateRelationship="11ea2f70-8009-4b9d-b099-5e577fd85591"/>
+        <sourceConnection xsi:type="archimate:Connection" id="d4b6384b-7bd0-46da-b160-3591768520b0" source="e8f44bd4-7b09-4e93-97a4-0461a4cf4f02" target="57bf9995-08c4-41f4-9144-1ea76537f303" archimateRelationship="b42e098e-f8e9-48a6-9786-1de691e9e707"/>
+        <sourceConnection xsi:type="archimate:Connection" id="3fb27b61-a54b-4d25-943b-1c5259fe11d0" source="e8f44bd4-7b09-4e93-97a4-0461a4cf4f02" target="17f367b2-05f9-4442-a836-699ce91317f0" archimateRelationship="8061137c-057b-42fe-b50e-08493914d415"/>
+        <sourceConnection xsi:type="archimate:Connection" id="01181207-8077-4ecd-a504-96a08fc5e545" source="e8f44bd4-7b09-4e93-97a4-0461a4cf4f02" target="2739c5ab-bc74-4336-a3cd-dd7c49e76f33" archimateRelationship="82858c74-fa51-4408-a384-50f99602243a"/>
+        <child xsi:type="archimate:DiagramObject" id="e9187ff9-d1a5-4c91-95c8-4d93d63c055e" targetConnections="2b68c129-195b-4830-a01a-0bfacd71b030" archimateElement="d61e514e-6042-4efb-8e3a-ab4c7f021115">
+          <bounds x="128" y="48" width="73" height="37"/>
+          <sourceConnection xsi:type="archimate:Connection" id="0af6fee7-c6b2-462d-b7b4-42ac0ec2d0b7" source="e9187ff9-d1a5-4c91-95c8-4d93d63c055e" target="57bf9995-08c4-41f4-9144-1ea76537f303" archimateRelationship="dd868d9a-3da0-43c9-b8b7-c53381a29fe1"/>
+          <sourceConnection xsi:type="archimate:Connection" id="16ba0ec6-d60f-4e0e-8a94-a894fff7d603" source="e9187ff9-d1a5-4c91-95c8-4d93d63c055e" target="cd408980-f4c0-42ef-98f1-93a58561b4a2" archimateRelationship="0fd499a8-dde4-49b0-a3c4-7cedc2a26d9b"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="57bf9995-08c4-41f4-9144-1ea76537f303" targetConnections="0af6fee7-c6b2-462d-b7b4-42ac0ec2d0b7 7e0e1278-1749-493f-a301-0890e020b957 d4b6384b-7bd0-46da-b160-3591768520b0" archimateElement="98f08e2a-55bb-4cf3-88f8-a72c328068e1">
+          <bounds x="213" y="24" width="104" height="73"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="17f367b2-05f9-4442-a836-699ce91317f0" targetConnections="1c94b4c3-ad9d-4dd8-8e0c-c9efa3ee806a 3fb27b61-a54b-4d25-943b-1c5259fe11d0" archimateElement="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe">
+          <bounds x="331" y="24" width="104" height="73"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="2739c5ab-bc74-4336-a3cd-dd7c49e76f33" targetConnections="93992ed1-41d0-44ec-817a-1c47b8e24cfb 01181207-8077-4ecd-a504-96a08fc5e545" archimateElement="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349">
+          <bounds x="446" y="23" width="104" height="73"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="0b6a41c8-0d6c-4a99-b4a7-3a5a8c4c3af9" archimateElement="64672752-1b6b-4fd1-ab2f-9f8eff29d024">
+          <bounds x="560" y="23" width="104" height="73"/>
+          <sourceConnection xsi:type="archimate:Connection" id="ade2dea2-9010-4137-bdc9-38317f8f480a" source="0b6a41c8-0d6c-4a99-b4a7-3a5a8c4c3af9" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="b773c016-9fae-4909-8927-39901fdfbb37"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="d212203a-2da1-48e0-b47b-ca409f18654d" archimateElement="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac">
+        <bounds x="1452" y="24" width="636" height="396"/>
+        <sourceConnection xsi:type="archimate:Connection" id="37ebc24a-d2bd-4689-ae86-e00361e4ae19" source="d212203a-2da1-48e0-b47b-ca409f18654d" target="420bc620-3fde-4bcf-bee7-6aa87c775412" archimateRelationship="17b2804b-bcb2-400f-b93c-827ca8523d9e"/>
+        <sourceConnection xsi:type="archimate:Connection" id="2ae5d749-e8ff-4c19-b580-3d399db3d47c" source="d212203a-2da1-48e0-b47b-ca409f18654d" target="3f78b47b-b744-4def-97d9-016e4cf27d94" archimateRelationship="a9609e08-a8e3-4e25-8f10-7e68029931d2"/>
+        <sourceConnection xsi:type="archimate:Connection" id="08ca6f3c-1768-4b24-88ac-ffd1f0fb34f8" source="d212203a-2da1-48e0-b47b-ca409f18654d" target="3a1c365f-24a6-4c5c-ac2c-ca44cb3c0937" archimateRelationship="c801c856-c345-4a22-9a98-42569a3220bd"/>
+        <sourceConnection xsi:type="archimate:Connection" id="343df1e1-35b5-4e6d-8a2c-88865072cce7" source="d212203a-2da1-48e0-b47b-ca409f18654d" target="b6d5020b-c5a8-4a47-879a-21f84404450b" archimateRelationship="3fdeebe9-63d6-4c7f-911f-820cf135848c"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e220f2a5-c626-4392-a016-b656c546e9b4" source="d212203a-2da1-48e0-b47b-ca409f18654d" target="21f19658-f9c3-470f-a698-16e8bae88ee2" archimateRelationship="e94b7f72-17c2-4873-b380-d13b4d41bac5"/>
+        <child xsi:type="archimate:DiagramObject" id="420bc620-3fde-4bcf-bee7-6aa87c775412" targetConnections="d1f4584d-f610-4064-b73d-4987329a997a 39f08a36-983a-4a4e-b3ef-66725829c6ec 37ebc24a-d2bd-4689-ae86-e00361e4ae19" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
+          <bounds x="24" y="48" width="144" height="65"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="3f78b47b-b744-4def-97d9-016e4cf27d94" targetConnections="ea53734c-fcea-4246-acb7-161e80e6a54e 2ae5d749-e8ff-4c19-b580-3d399db3d47c" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
+          <bounds x="24" y="132" width="144" height="65"/>
+          <sourceConnection xsi:type="archimate:Connection" id="e5a12541-0f9e-4ad0-90e6-146f82929abe" source="3f78b47b-b744-4def-97d9-016e4cf27d94" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="8ea14bb7-705c-4a3f-9fb7-40f18af5afbb"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="3a1c365f-24a6-4c5c-ac2c-ca44cb3c0937" targetConnections="c651da22-f77f-4c99-b222-3e509f963433 08ca6f3c-1768-4b24-88ac-ffd1f0fb34f8" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
+          <bounds x="24" y="216" width="144" height="65"/>
+          <sourceConnection xsi:type="archimate:Connection" id="d6983425-ccf8-48a9-9059-fa2c48d8c133" source="3a1c365f-24a6-4c5c-ac2c-ca44cb3c0937" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="496117f5-e3ac-4e8c-be72-cfcab9cc996b"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="c2969638-4b19-45d0-9dce-eb8e07c61a8d" targetConnections="eff689e3-c353-48f2-8fe1-775d8c5a4dee" archimateElement="f925eb37-dc1e-4ab2-a179-808b431dcb0c">
+          <bounds x="264" y="96" width="144" height="84"/>
+          <sourceConnection xsi:type="archimate:Connection" id="ea53734c-fcea-4246-acb7-161e80e6a54e" source="c2969638-4b19-45d0-9dce-eb8e07c61a8d" target="3f78b47b-b744-4def-97d9-016e4cf27d94" archimateRelationship="ca528479-4583-4a63-880b-efdd032cdcb6"/>
+          <sourceConnection xsi:type="archimate:Connection" id="39f08a36-983a-4a4e-b3ef-66725829c6ec" source="c2969638-4b19-45d0-9dce-eb8e07c61a8d" target="420bc620-3fde-4bcf-bee7-6aa87c775412" archimateRelationship="0a90aced-35fd-499f-8aee-26de44bf636c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="c651da22-f77f-4c99-b222-3e509f963433" source="c2969638-4b19-45d0-9dce-eb8e07c61a8d" target="3a1c365f-24a6-4c5c-ac2c-ca44cb3c0937" archimateRelationship="4565571a-58a5-4483-9551-4dc1600b45c1"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="b6d5020b-c5a8-4a47-879a-21f84404450b" targetConnections="343df1e1-35b5-4e6d-8a2c-88865072cce7" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
+          <bounds x="480" y="120" width="133" height="108"/>
+          <sourceConnection xsi:type="archimate:Connection" id="eff689e3-c353-48f2-8fe1-775d8c5a4dee" source="b6d5020b-c5a8-4a47-879a-21f84404450b" target="c2969638-4b19-45d0-9dce-eb8e07c61a8d" archimateRelationship="c03146a8-2273-424b-bc6d-c2dd86f93e5c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="30b898a7-30ca-4766-b851-eb6dd7a5e225" source="b6d5020b-c5a8-4a47-879a-21f84404450b" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="6b11f94c-fad5-4ef3-acde-3a77b7cc9b4b">
+            <bendpoint startX="-500" startY="10" endX="500" endY="30"/>
+          </sourceConnection>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="21f19658-f9c3-470f-a698-16e8bae88ee2" targetConnections="e220f2a5-c626-4392-a016-b656c546e9b4" archimateElement="819e7e8c-a185-4b7b-b205-940fefcfe408">
+          <bounds x="24" y="300" width="144" height="65"/>
+          <sourceConnection xsi:type="archimate:Connection" id="292d166c-1168-425b-9f5f-f03cbf6b0eb5" source="21f19658-f9c3-470f-a698-16e8bae88ee2" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="89cb6502-27b4-4e3f-9003-025e782532c8"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="92941f14-6fa4-48f8-868a-9ddf12504b09" archimateElement="212f31b8-928f-4714-8aa2-542ecdb81468">
+        <bounds x="132" y="24" width="610" height="396"/>
+        <sourceConnection xsi:type="archimate:Connection" id="73a43d5f-d35d-48d9-ba66-e76dc825ed9d" source="92941f14-6fa4-48f8-868a-9ddf12504b09" target="9519245d-597d-4158-bda9-63c1e72c08df" archimateRelationship="db710967-fa2b-4904-87d4-5d28e548a07d"/>
+        <sourceConnection xsi:type="archimate:Connection" id="eb2d5f69-0c53-4fcb-b2e4-910c6172efc4" source="92941f14-6fa4-48f8-868a-9ddf12504b09" target="cf36706e-6496-4990-8e6c-c594a49e4183" archimateRelationship="30ba6a82-c6d3-4a27-83ce-9d8cde8750bd"/>
+        <sourceConnection xsi:type="archimate:Connection" id="0aaf8b2d-50ac-4367-b7da-c03386cc978f" source="92941f14-6fa4-48f8-868a-9ddf12504b09" target="1819c482-5a73-411c-8fb1-28f341e67679" archimateRelationship="b57e920c-ff16-47af-8706-b277376ee747"/>
+        <sourceConnection xsi:type="archimate:Connection" id="27e77df4-fb72-4b2e-8b24-76f1ec8bb24e" source="92941f14-6fa4-48f8-868a-9ddf12504b09" target="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" archimateRelationship="8adf2b0b-3bd8-40ce-8a75-a5e29b7aaa84"/>
+        <sourceConnection xsi:type="archimate:Connection" id="80281249-16ce-4ab1-a2d0-8e79a231ec27" source="92941f14-6fa4-48f8-868a-9ddf12504b09" target="52366da1-8872-484a-8954-dcba5c8b049b" archimateRelationship="a5bb98eb-6c1d-4921-a9c0-98c9aad8aad6"/>
+        <child xsi:type="archimate:DiagramObject" id="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" targetConnections="27e77df4-fb72-4b2e-8b24-76f1ec8bb24e" archimateElement="556907f5-b628-43fb-845c-db9cb756483a">
+          <bounds x="228" y="96" width="132" height="79"/>
+          <sourceConnection xsi:type="archimate:Connection" id="72b9d3a9-1063-4b82-a16e-6b2d58b58cd8" source="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" target="9519245d-597d-4158-bda9-63c1e72c08df" archimateRelationship="6ac270e4-3520-44ba-8784-77f217b03887"/>
+          <sourceConnection xsi:type="archimate:Connection" id="48ac5f9c-fffc-40f6-b18a-1f0435889e7b" source="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" target="cf36706e-6496-4990-8e6c-c594a49e4183" archimateRelationship="95c2def0-63c5-47e6-a79e-2ae528a5740d"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b6e329fc-39ab-4242-bf55-f182ffd95653" source="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" target="0da61933-9bf8-4240-a707-a04021678ec7" archimateRelationship="7d00fe16-6ca1-4950-8365-1945ab74a12f"/>
+          <sourceConnection xsi:type="archimate:Connection" id="1c4aa629-5b71-4700-9dd7-92cf52af8145" source="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" target="1819c482-5a73-411c-8fb1-28f341e67679" archimateRelationship="9063ad94-b467-48df-97c6-3d97233391ce"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="1819c482-5a73-411c-8fb1-28f341e67679" targetConnections="0aaf8b2d-50ac-4367-b7da-c03386cc978f 1c4aa629-5b71-4700-9dd7-92cf52af8145" archimateElement="c2bcebbc-2082-490d-aa5f-8606e59e3833">
+          <bounds x="444" y="216" width="144" height="65"/>
+          <sourceConnection xsi:type="archimate:Connection" id="37dc4e7b-b9be-4df6-b38b-73ff22db929e" source="1819c482-5a73-411c-8fb1-28f341e67679" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="30c84a11-4798-4a9c-9840-d23053e7bd53"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="0da61933-9bf8-4240-a707-a04021678ec7" targetConnections="848912ca-a1cb-43d7-b58b-548fa642a923 b6e329fc-39ab-4242-bf55-f182ffd95653" archimateElement="538aa797-e00b-442f-af83-9a8e7e85aadd">
+          <bounds x="444" y="48" width="144" height="65"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="cf36706e-6496-4990-8e6c-c594a49e4183" targetConnections="eb2d5f69-0c53-4fcb-b2e4-910c6172efc4 3f723213-4be1-48ef-9c93-322befe674bd 48ac5f9c-fffc-40f6-b18a-1f0435889e7b" archimateElement="a46b13f6-899f-4651-bccd-67685ea0ab9d">
+          <bounds x="444" y="132" width="144" height="65"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="9519245d-597d-4158-bda9-63c1e72c08df" targetConnections="73a43d5f-d35d-48d9-ba66-e76dc825ed9d 72b9d3a9-1063-4b82-a16e-6b2d58b58cd8" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
+          <bounds x="24" y="108" width="133" height="108"/>
+          <sourceConnection xsi:type="archimate:Connection" id="8be11109-bb70-4b85-8a5b-9f1114a57907" source="9519245d-597d-4158-bda9-63c1e72c08df" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="faf184fe-1470-45c9-9e0f-e4bc4b26aa32">
+            <bendpoint startX="380" startY="14" endX="-386" endY="30"/>
+          </sourceConnection>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="52366da1-8872-484a-8954-dcba5c8b049b" targetConnections="80281249-16ce-4ab1-a2d0-8e79a231ec27" archimateElement="17bc30f6-6291-43bc-b2e5-ef5202bc18e4">
+          <bounds x="444" y="300" width="144" height="65"/>
+          <sourceConnection xsi:type="archimate:Connection" id="9bb697f1-4a75-4882-8358-e558fbf99e2a" source="52366da1-8872-484a-8954-dcba5c8b049b" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="7cc89761-4fb9-4a12-b8a3-a041f3e331cc"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="fe525f10-a933-4d6e-b29a-65f1d5d18930" targetConnections="454958ef-c876-42d3-ad08-1d405ad8cee4 e5a12541-0f9e-4ad0-90e6-146f82929abe d6983425-ccf8-48a9-9059-fa2c48d8c133 30b898a7-30ca-4766-b851-eb6dd7a5e225 8be11109-bb70-4b85-8a5b-9f1114a57907 37dc4e7b-b9be-4df6-b38b-73ff22db929e ade2dea2-9010-4137-bdc9-38317f8f480a 292d166c-1168-425b-9f5f-f03cbf6b0eb5 9bb697f1-4a75-4882-8358-e558fbf99e2a" archimateElement="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba">
+        <bounds x="768" y="180" width="660" height="95"/>
+        <sourceConnection xsi:type="archimate:Connection" id="1c94b4c3-ad9d-4dd8-8e0c-c9efa3ee806a" source="fe525f10-a933-4d6e-b29a-65f1d5d18930" target="17f367b2-05f9-4442-a836-699ce91317f0" archimateRelationship="0d084930-9cb3-4fb4-a204-f0357d34ac4c"/>
+        <sourceConnection xsi:type="archimate:Connection" id="7e0e1278-1749-493f-a301-0890e020b957" source="fe525f10-a933-4d6e-b29a-65f1d5d18930" target="57bf9995-08c4-41f4-9144-1ea76537f303" archimateRelationship="237529d5-cb2a-4d39-94f3-1b45aecb0003"/>
+        <sourceConnection xsi:type="archimate:Connection" id="93992ed1-41d0-44ec-817a-1c47b8e24cfb" source="fe525f10-a933-4d6e-b29a-65f1d5d18930" target="2739c5ab-bc74-4336-a3cd-dd7c49e76f33" archimateRelationship="4dc96ee3-5458-4d17-a544-a381a62fb28a"/>
+        <sourceConnection xsi:type="archimate:Connection" id="3f723213-4be1-48ef-9c93-322befe674bd" source="fe525f10-a933-4d6e-b29a-65f1d5d18930" target="cf36706e-6496-4990-8e6c-c594a49e4183" archimateRelationship="796bacf1-b115-4589-933c-de8ca5a60a6b"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="cd408980-f4c0-42ef-98f1-93a58561b4a2" targetConnections="16ba0ec6-d60f-4e0e-8a94-a894fff7d603" archimateElement="8532f211-fbcb-4255-a32d-91871c7336be">
+        <bounds x="768" y="312" width="104" height="73"/>
+        <sourceConnection xsi:type="archimate:Connection" id="454958ef-c876-42d3-ad08-1d405ad8cee4" source="cd408980-f4c0-42ef-98f1-93a58561b4a2" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="b4296792-91ba-4d9b-9625-d9437d280c57"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="2ec2ccf8-bf60-4945-a32d-255372d59fbf" archimateElement="ec24ee51-08ed-465b-a883-ae6776b24eb8">
+        <bounds x="768" y="72" width="660" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="d1f4584d-f610-4064-b73d-4987329a997a" source="2ec2ccf8-bf60-4945-a32d-255372d59fbf" target="420bc620-3fde-4bcf-bee7-6aa87c775412" archimateRelationship="27246a90-8ce3-483e-a388-fe8f927e1ca5"/>
+        <sourceConnection xsi:type="archimate:Connection" id="848912ca-a1cb-43d7-b58b-548fa642a923" source="2ec2ccf8-bf60-4945-a32d-255372d59fbf" target="0da61933-9bf8-4240-a707-a04021678ec7" archimateRelationship="be8eefda-496f-4f0b-8362-6f30ba84140e"/>
+      </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Deployment topology #1" id="9f0ecd93-71c9-4fc3-b3b5-cb3422874279">
+      <child xsi:type="archimate:DiagramObject" id="cc8a2532-35b1-496a-bea5-5167a3b74583" archimateElement="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac">
+        <bounds x="1152" y="16" width="674" height="978"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5919a566-6928-466a-a832-4d761a1b02fc" source="cc8a2532-35b1-496a-bea5-5167a3b74583" target="ae4559fc-cf9a-47a8-8b71-4b23a916c468" archimateRelationship="17b2804b-bcb2-400f-b93c-827ca8523d9e"/>
+        <sourceConnection xsi:type="archimate:Connection" id="7d7d7a4c-e6d2-4c17-9e25-9674e001a815" source="cc8a2532-35b1-496a-bea5-5167a3b74583" target="ae4559fc-cf9a-47a8-8b71-4b23a916c468" archimateRelationship="17b2804b-bcb2-400f-b93c-827ca8523d9e"/>
+        <sourceConnection xsi:type="archimate:Connection" id="765fe292-a8cf-459a-bf29-c7845a8ff235" source="cc8a2532-35b1-496a-bea5-5167a3b74583" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="3fdeebe9-63d6-4c7f-911f-820cf135848c"/>
+        <sourceConnection xsi:type="archimate:Connection" id="679594de-509f-44a4-ba70-550396ada5d0" source="cc8a2532-35b1-496a-bea5-5167a3b74583" target="039e3b6f-93ce-418e-8c67-f7d608b9bab3" archimateRelationship="a9609e08-a8e3-4e25-8f10-7e68029931d2"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8a3b33b9-83e9-4669-b90c-edef0c16ff1c" source="cc8a2532-35b1-496a-bea5-5167a3b74583" target="ac0da59a-a9b6-447a-a997-b63e18573dc5" archimateRelationship="c801c856-c345-4a22-9a98-42569a3220bd"/>
+        <child xsi:type="archimate:DiagramObject" id="ae4559fc-cf9a-47a8-8b71-4b23a916c468" targetConnections="5919a566-6928-466a-a832-4d761a1b02fc 7d7d7a4c-e6d2-4c17-9e25-9674e001a815" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
+          <bounds x="65" y="29" width="196" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="722992ef-c758-4f34-92d7-31afeb047c65" source="ae4559fc-cf9a-47a8-8b71-4b23a916c468" target="fd503229-02f9-40f7-aeaa-5bb72030a899" archimateRelationship="b85300bf-77ed-49c7-84a8-011be915cee2"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a9d606af-1e06-41f5-887f-36f8fbfade49" source="ae4559fc-cf9a-47a8-8b71-4b23a916c468" target="322d2fa3-56ad-43e4-96e3-f64f733ed393" archimateRelationship="885e9e6f-9da6-4924-8aaf-d8c5ab20552b"/>
+          <child xsi:type="archimate:DiagramObject" id="fd503229-02f9-40f7-aeaa-5bb72030a899" targetConnections="722992ef-c758-4f34-92d7-31afeb047c65" archimateElement="68e59636-1f53-4336-9cfd-64fa6acae825">
+            <bounds x="14" y="40" width="151" height="55"/>
+            <sourceConnection xsi:type="archimate:Connection" id="6d91fde9-7faf-4783-a5f4-3500ca5de394" source="fd503229-02f9-40f7-aeaa-5bb72030a899" target="0d9cde6f-9382-479a-90d5-5515d57636c8" archimateRelationship="caab7f6b-ecb8-4257-85ef-bbff50ef681b"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="4cbbb745-e6ea-4aee-977d-2178183f4ec2" targetConnections="765fe292-a8cf-459a-bf29-c7845a8ff235 a8e3b84c-e756-4133-9d36-ab930d551cc0 7a3a94ec-ad77-4226-83c0-b2a8ca1c7fbc 70c94ee9-a972-4c1b-9235-130ca7751371 b14bb356-0b52-4c71-b0fa-ea36f0d27070" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
+          <bounds x="365" y="352" width="274" height="271"/>
+          <sourceConnection xsi:type="archimate:Connection" id="5a839017-abee-4fd2-a366-bdcc4915c4fe" source="4cbbb745-e6ea-4aee-977d-2178183f4ec2" target="72327a87-82a9-4f3f-98db-1c358ab5b6df" archimateRelationship="fec9ce18-5dfb-4483-b947-1d4dd4709b45"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="039e3b6f-93ce-418e-8c67-f7d608b9bab3" targetConnections="679594de-509f-44a4-ba70-550396ada5d0 88994f40-85e0-4745-850b-0816b5fe1bed" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
+          <bounds x="64" y="567" width="194" height="103"/>
+          <sourceConnection xsi:type="archimate:Connection" id="14b33f6c-8fbb-4b98-ab69-c813a1b57aca" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="454f2fd3-e258-4bc8-95d6-a5cfb9c4cdd1" archimateRelationship="dd6d220f-2e28-4568-9b32-05078dd07d50"/>
+          <sourceConnection xsi:type="archimate:Connection" id="260d4613-78a3-4e5b-ae76-097bd7787447" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" archimateRelationship="3de150e4-3c9e-45ad-9c44-fc2dccf967a3">
+            <bendpoint startX="-82" startY="-145" endX="290" endY="36"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="a8e3b84c-e756-4133-9d36-ab930d551cc0" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="ce7896f2-7830-4829-bc08-5d822b5ac10b"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b52af52d-d20e-430b-a883-a49a5acb2f6b" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="1a65f425-6273-4339-badf-15bc2122b7fa">
+            <bendpoint startX="-186" startY="-18" endX="878" endY="53"/>
+            <bendpoint startX="-192" startY="-103" endX="882" endY="34"/>
+            <bendpoint startX="-519" startY="-76" endX="545" endY="-6"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="b4a92e65-f269-4400-9519-05a1dc26d63b" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="2da9702d-601c-44de-9b5f-8ca13b2ce338" archimateRelationship="0bef2725-e92f-4ade-887e-3bd76eab034c"/>
+          <child xsi:type="archimate:DiagramObject" id="454f2fd3-e258-4bc8-95d6-a5cfb9c4cdd1" targetConnections="14b33f6c-8fbb-4b98-ab69-c813a1b57aca" archimateElement="1a8879f8-06ce-4925-93ab-ff2222e347aa">
+            <bounds x="21" y="41" width="133" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="ac0da59a-a9b6-447a-a997-b63e18573dc5" targetConnections="8a3b33b9-83e9-4669-b90c-edef0c16ff1c d55b5255-5a38-4c3d-924c-102ceb0070ff" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
+          <bounds x="67" y="820" width="196" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="8b1528bb-d013-4d6c-abc8-c3ce341659b5" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="9404da78-8721-4fa9-b367-b99217b83f22" archimateRelationship="67b2f7a1-c01c-464b-8caa-b4a9744f35ae"/>
+          <sourceConnection xsi:type="archimate:Connection" id="7a3a94ec-ad77-4226-83c0-b2a8ca1c7fbc" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="59d8bd29-7642-49a0-9c2f-48b13fa3fdfc">
+            <bendpoint startX="338" startY="1" endX="-2" endY="356"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="88c62c2e-8249-43d0-b8a7-86b4ac12694e" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" archimateRelationship="0e0d90ea-f06a-414b-9eab-4e425f96d110"/>
+          <sourceConnection xsi:type="archimate:Connection" id="ded17a8a-f591-460f-8b90-be187b7e5fa3" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="88af58c4-9adf-4338-a54b-352b34d04b76" archimateRelationship="bf3a3e9b-d6d1-4989-8ef7-021d1f136913"/>
+          <child xsi:type="archimate:DiagramObject" id="9404da78-8721-4fa9-b367-b99217b83f22" targetConnections="8b1528bb-d013-4d6c-abc8-c3ce341659b5" archimateElement="51eacaa9-ed7b-4307-915c-05a114b2a19d">
+            <bounds x="21" y="41" width="141" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="2da9702d-601c-44de-9b5f-8ca13b2ce338" targetConnections="b4a92e65-f269-4400-9519-05a1dc26d63b" archimateElement="9dc22627-f969-46c8-ac76-9f1ac9b35767" type="1">
+          <bounds x="64" y="496" width="194" height="43"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="72327a87-82a9-4f3f-98db-1c358ab5b6df" targetConnections="5a839017-abee-4fd2-a366-bdcc4915c4fe" archimateElement="0984a188-6642-400c-a42f-20277624eee9" type="1">
+          <bounds x="365" y="223" width="274" height="93"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="88af58c4-9adf-4338-a54b-352b34d04b76" targetConnections="ded17a8a-f591-460f-8b90-be187b7e5fa3" archimateElement="7c846708-edd4-4a3a-afad-a711b21abeb4" type="1">
+          <bounds x="67" y="741" width="196" height="55"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="0d9cde6f-9382-479a-90d5-5515d57636c8" targetConnections="6d91fde9-7faf-4783-a5f4-3500ca5de394" archimateElement="197d58a5-2131-41e0-8ec3-37bc46ed9b3d" type="1">
+          <bounds x="365" y="57" width="129" height="68"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="c7defef5-09d4-41c1-a76d-da3e521419c5" archimateElement="efbf9f7a-7b30-462f-a471-3cc2049014b5">
+        <bounds x="770" y="16" width="362" height="978"/>
+        <sourceConnection xsi:type="archimate:Connection" id="163aacdb-5bef-40db-9b82-d21ffe3175aa" source="c7defef5-09d4-41c1-a76d-da3e521419c5" target="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" archimateRelationship="f28c0a1d-12f1-4f22-9add-268879bc8a51"/>
+        <sourceConnection xsi:type="archimate:Connection" id="f60dd721-1d5f-49a6-863b-804af74a7ce4" source="c7defef5-09d4-41c1-a76d-da3e521419c5" target="22f86c10-9ab5-46f0-937a-5b6f932871d5" archimateRelationship="b42e098e-f8e9-48a6-9786-1de691e9e707"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ccb78894-4cbf-4ed2-86b4-23bef3675d82" source="c7defef5-09d4-41c1-a76d-da3e521419c5" target="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" archimateRelationship="8061137c-057b-42fe-b50e-08493914d415"/>
+        <child xsi:type="archimate:DiagramObject" id="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" targetConnections="163aacdb-5bef-40db-9b82-d21ffe3175aa 7d504256-873f-49e8-ba1c-7203b9ba1c14" archimateElement="8532f211-fbcb-4255-a32d-91871c7336be">
+          <bounds x="68" y="716" width="205" height="78"/>
+          <sourceConnection xsi:type="archimate:Connection" id="70c94ee9-a972-4c1b-9235-130ca7751371" source="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="604120c2-2acc-4b05-a43d-c707a73ad5dc">
+            <bendpoint startX="657" endX="-80" endY="239"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="3e3c38fa-20f6-451d-b15d-2451986cff47" source="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="b8077982-bc5b-42e6-baad-9a371e82443c">
+            <bendpoint startX="-627" startY="6" endX="61" endY="245"/>
+          </sourceConnection>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="22f86c10-9ab5-46f0-937a-5b6f932871d5" targetConnections="f60dd721-1d5f-49a6-863b-804af74a7ce4" archimateElement="98f08e2a-55bb-4cf3-88f8-a72c328068e1">
+          <bounds x="68" y="594" width="205" height="100"/>
+          <sourceConnection xsi:type="archimate:Connection" id="1e49dc22-018d-44fc-b41c-6ffcd057e7d3" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="521a3ab7-857d-4319-b150-848d7e62010a" archimateRelationship="f4d55798-6548-4f2b-8a36-dfb103680504"/>
+          <sourceConnection xsi:type="archimate:Connection" id="7d504256-873f-49e8-ba1c-7203b9ba1c14" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" archimateRelationship="4ccd9580-1076-4ab8-9e7c-51b10d00aa48"/>
+          <sourceConnection xsi:type="archimate:Connection" id="88994f40-85e0-4745-850b-0816b5fe1bed" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="039e3b6f-93ce-418e-8c67-f7d608b9bab3" archimateRelationship="b1837450-f7fb-4eb5-8d35-95206ec0ad1c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="496da764-66cb-4cc2-bad1-b2c5b2c3f094" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="7551b95a-b261-4058-8d05-12e2b1b33b70" archimateRelationship="dbe8aa22-0fa9-4cf4-9585-78e68a698731"/>
+          <child xsi:type="archimate:DiagramObject" id="521a3ab7-857d-4319-b150-848d7e62010a" targetConnections="1e49dc22-018d-44fc-b41c-6ffcd057e7d3" archimateElement="e573296a-1aac-4c71-871c-1baf2417c996">
+            <bounds x="17" y="45" width="152" height="47"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" targetConnections="260d4613-78a3-4e5b-ae76-097bd7787447 ccb78894-4cbf-4ed2-86b4-23bef3675d82" archimateElement="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe">
+          <bounds x="68" y="381" width="205" height="113"/>
+          <sourceConnection xsi:type="archimate:Connection" id="7248a965-43e8-4069-97bf-b5b796f79751" source="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" target="1561f4ae-0fff-4436-97ca-b2e9347b0186" archimateRelationship="3ca5b18c-b380-4be6-95f6-d6301b907ef5"/>
+          <sourceConnection xsi:type="archimate:Connection" id="2cdfbe62-9fb3-421d-bd23-f47f9b92b83a" source="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="6188230a-d639-46ea-9351-4bd0e798f98e"/>
+          <sourceConnection xsi:type="archimate:Connection" id="7e680171-eb4e-4d4e-931a-8da5b30f10ca" source="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" target="f99d35cb-eade-4648-9f73-718fa8155c97" archimateRelationship="8d9b2549-3ec1-40a7-a2bf-709d6c667325"/>
+          <child xsi:type="archimate:DiagramObject" id="1561f4ae-0fff-4436-97ca-b2e9347b0186" targetConnections="7248a965-43e8-4069-97bf-b5b796f79751" archimateElement="10cb9a93-25d4-4da1-8964-c183b3ff910c">
+            <bounds x="20" y="47" width="152" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="e1337d67-2fc2-4f98-b87e-446c41cd22a5" archimateElement="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349">
+          <bounds x="70" y="185" width="204" height="109"/>
+          <sourceConnection xsi:type="archimate:Connection" id="98c0b577-10d7-4b50-a784-f587880399ea" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="289762f7-5dbc-47d6-b151-929e3c48c7a1" archimateRelationship="3dfc3dbf-5711-45b6-930a-0dc44678676a"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b14bb356-0b52-4c71-b0fa-ea36f0d27070" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="9102c6a7-d07f-4de0-94d7-273bb7bca236">
+            <bendpoint startX="409" startY="17" endX="-307" endY="-215"/>
+            <bendpoint startX="410" startY="142" endX="-306" endY="-90"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="8202fcb6-2a06-42ed-acd7-5092c9c7e32b" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="5ad8159f-f033-40fd-977d-34f2694d728b">
+            <bendpoint startX="-307" startY="16" endX="394" endY="-210"/>
+            <bendpoint startX="-296" startY="134" endX="391" endY="-98"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="e82ecd83-1ab0-4fd7-9d1b-d008d447df6f" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="12a02288-f1ba-4dc8-803a-dd87c10bdd00" archimateRelationship="e08143cb-a72b-4f01-b442-a8c905603be7"/>
+          <child xsi:type="archimate:DiagramObject" id="289762f7-5dbc-47d6-b151-929e3c48c7a1" targetConnections="98c0b577-10d7-4b50-a784-f587880399ea" archimateElement="fede8dba-b24e-4347-9487-e9901da917f9">
+            <bounds x="22" y="52" width="148" height="47"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="f99d35cb-eade-4648-9f73-718fa8155c97" targetConnections="7e680171-eb4e-4d4e-931a-8da5b30f10ca" archimateElement="83a086f5-68c0-475d-88e8-c53fc033a533" type="1">
+          <bounds x="69" y="307" width="205" height="43"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="12a02288-f1ba-4dc8-803a-dd87c10bdd00" targetConnections="e82ecd83-1ab0-4fd7-9d1b-d008d447df6f" archimateElement="5647d2da-812c-4a0f-af6e-bac94daa4aeb" type="1">
+          <bounds x="68" y="93" width="204" height="55"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="47e32f77-111c-490b-b5d4-98b713f7e7bc" archimateElement="212f31b8-928f-4714-8aa2-542ecdb81468">
+        <bounds x="72" y="16" width="674" height="978"/>
+        <sourceConnection xsi:type="archimate:Connection" id="1e20837a-b01d-4693-a0bc-4edb09609972" source="47e32f77-111c-490b-b5d4-98b713f7e7bc" target="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" archimateRelationship="b57e920c-ff16-47af-8706-b277376ee747"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e809c647-c0c6-411e-8eed-eddd71587e50" source="47e32f77-111c-490b-b5d4-98b713f7e7bc" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="db710967-fa2b-4904-87d4-5d28e548a07d"/>
+        <sourceConnection xsi:type="archimate:Connection" id="a74b3e65-6579-45ed-9ab8-37a581b54c01" source="47e32f77-111c-490b-b5d4-98b713f7e7bc" target="7551b95a-b261-4058-8d05-12e2b1b33b70" archimateRelationship="30ba6a82-c6d3-4a27-83ce-9d8cde8750bd"/>
+        <child xsi:type="archimate:DiagramObject" id="7551b95a-b261-4058-8d05-12e2b1b33b70" targetConnections="a74b3e65-6579-45ed-9ab8-37a581b54c01 496da764-66cb-4cc2-bad1-b2c5b2c3f094" archimateElement="a46b13f6-899f-4651-bccd-67685ea0ab9d">
+          <bounds x="409" y="572" width="194" height="103"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a1936d07-6c4c-457c-895c-876da16d7561" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="00c4a55a-5ec6-42e1-91fc-de97c090c9ec"/>
+          <sourceConnection xsi:type="archimate:Connection" id="6cb388b0-1f6f-4428-b5fd-f7b6b53b4d97" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="a9247692-5ec4-4f7d-b797-9f6d750eef2c" archimateRelationship="6652b746-6c44-479c-b3e9-5f901199d7ef"/>
+          <sourceConnection xsi:type="archimate:Connection" id="85cd0674-d91f-423f-aae4-eda86998820b" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="27c6d20e-a463-43c0-a923-2e097816b34b" archimateRelationship="32f934ac-0d3b-43d1-9f47-447f6e564ba7"/>
+          <child xsi:type="archimate:DiagramObject" id="a9247692-5ec4-4f7d-b797-9f6d750eef2c" targetConnections="6cb388b0-1f6f-4428-b5fd-f7b6b53b4d97" archimateElement="8efc3e85-150e-4e1d-91f5-8989b1c5b89f">
+            <bounds x="21" y="41" width="133" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" targetConnections="cc3457cb-c306-4a3c-abec-c76682da886f 79075b5b-919e-421c-8e84-12e0193315fc a1936d07-6c4c-457c-895c-876da16d7561 e809c647-c0c6-411e-8eed-eddd71587e50 8202fcb6-2a06-42ed-acd7-5092c9c7e32b 2cdfbe62-9fb3-421d-bd23-f47f9b92b83a 3e3c38fa-20f6-451d-b15d-2451986cff47 b52af52d-d20e-430b-a883-a49a5acb2f6b" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
+          <bounds x="30" y="345" width="274" height="271"/>
+          <sourceConnection xsi:type="archimate:Connection" id="5012fc94-bb3f-4169-bd3c-125c69d8476d" source="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" target="af1e1f82-d762-4e1c-b94c-28a68482a967" archimateRelationship="65eeae27-537c-48c0-9390-455f475c2800"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" targetConnections="1e20837a-b01d-4693-a0bc-4edb09609972 88c62c2e-8249-43d0-b8a7-86b4ac12694e" archimateElement="c2bcebbc-2082-490d-aa5f-8606e59e3833">
+          <bounds x="411" y="826" width="196" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="d2481ae9-a94a-4dc6-a1df-4719e46e21ca" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="de9260ad-5f12-48cf-a893-56a0aa37e98a" archimateRelationship="c63e1909-e2fe-4516-b642-d6749c9ad79c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="d55b5255-5a38-4c3d-924c-102ceb0070ff" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="ac0da59a-a9b6-447a-a997-b63e18573dc5" archimateRelationship="bce71955-7d5f-4f3d-a47c-a5b0b5af71d8"/>
+          <sourceConnection xsi:type="archimate:Connection" id="79075b5b-919e-421c-8e84-12e0193315fc" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="254d9661-8126-4963-8d40-e57116fa4186">
+            <bendpoint startX="-356" startY="5" endX="-14" endY="360"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="e7b59793-4e36-45a2-bb89-87bd90810527" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="c597dd75-a908-492e-b3b2-e93e8273e81c" archimateRelationship="d965cc0d-8876-416d-a61a-e12259efd4f9"/>
+          <child xsi:type="archimate:DiagramObject" id="de9260ad-5f12-48cf-a893-56a0aa37e98a" targetConnections="d2481ae9-a94a-4dc6-a1df-4719e46e21ca" archimateElement="cc875beb-f4ff-4952-9600-5eae35fb0d10">
+            <bounds x="21" y="41" width="141" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="322d2fa3-56ad-43e4-96e3-f64f733ed393" targetConnections="a9d606af-1e06-41f5-887f-36f8fbfade49" archimateElement="538aa797-e00b-442f-af83-9a8e7e85aadd">
+          <bounds x="411" y="35" width="196" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="602a2b42-42f8-4124-ba67-e4c03ba0b09e" source="322d2fa3-56ad-43e4-96e3-f64f733ed393" target="8f2f5add-4047-4bbe-a7f2-82f6247599d8" archimateRelationship="49c8dabe-7bb4-4d12-b9c6-1cbd98f0c9a3"/>
+          <sourceConnection xsi:type="archimate:Connection" id="cc3457cb-c306-4a3c-abec-c76682da886f" source="322d2fa3-56ad-43e4-96e3-f64f733ed393" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="3a2019bf-1f10-4bd8-9004-073eccf5289a"/>
+          <child xsi:type="archimate:DiagramObject" id="8f2f5add-4047-4bbe-a7f2-82f6247599d8" targetConnections="602a2b42-42f8-4124-ba67-e4c03ba0b09e" archimateElement="aae5673b-3220-4959-bd3b-a4351a94194d">
+            <bounds x="14" y="40" width="151" height="55"/>
+            <sourceConnection xsi:type="archimate:Connection" id="23c76cfe-4519-4ee6-99aa-2300581faaf8" source="8f2f5add-4047-4bbe-a7f2-82f6247599d8" target="d0288160-d92d-4888-8bb4-7dfb83b2676f" archimateRelationship="4d511da2-7df6-4beb-b47c-78b2f788e5f5"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="af1e1f82-d762-4e1c-b94c-28a68482a967" targetConnections="5012fc94-bb3f-4169-bd3c-125c69d8476d" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75" type="1">
+          <bounds x="30" y="214" width="274" height="93"/>
+          <sourceConnection xsi:type="archimate:Connection" id="6f94354e-629a-4ae7-9a3f-5d38214b491e" source="af1e1f82-d762-4e1c-b94c-28a68482a967" target="5562e0e3-7aa7-470f-aa76-641ada75095d" archimateRelationship="8d84949c-da2f-456f-9c85-eb903765cea5"/>
+          <child xsi:type="archimate:DiagramObject" id="5562e0e3-7aa7-470f-aa76-641ada75095d" targetConnections="6f94354e-629a-4ae7-9a3f-5d38214b491e" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" type="1">
+            <bounds x="48" y="26" width="177" height="52"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="d0288160-d92d-4888-8bb4-7dfb83b2676f" targetConnections="23c76cfe-4519-4ee6-99aa-2300581faaf8" archimateElement="5e3cba4d-6785-4a6a-80e7-ccabcb45c0e3" type="1">
+          <bounds x="175" y="62" width="129" height="68"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="27c6d20e-a463-43c0-a923-2e097816b34b" targetConnections="85cd0674-d91f-423f-aae4-eda86998820b" archimateElement="2cc22b82-8760-46b4-80cb-118fb3cb04ee" type="1">
+          <bounds x="409" y="497" width="194" height="43"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="c597dd75-a908-492e-b3b2-e93e8273e81c" targetConnections="e7b59793-4e36-45a2-bb89-87bd90810527" archimateElement="b7b2aa18-f4d7-4341-945c-03837cb989a6" type="1">
+          <bounds x="412" y="742" width="196" height="55"/>
+        </child>
+      </child>
+      <documentation>This diagram shows how the application components (or funtions, to be decided) defined in the ISA can be deployed to nodes in the technology architecture. As the SMP and AP can be deployed both centrally within a member state but also locally at a DC/DP this diagraim shows only one variant. 
+I have made the separation between BDXL back-end and the DNS server explicit in this diagram, but this means that is not easy to show, in a vsiually nice way, that the collaboration of both realize the BDXL application component. Maybe in this diagram the BDXL server should be just one node. That for normal operations however the DNS is used hower is important for realibility. </documentation>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Trust management" id="57970331-bf90-498c-8ad5-4248bdfcd5ba">
+      <child xsi:type="archimate:DiagramObject" id="f67eadc1-b27c-4d62-8165-319797b368b9" archimateElement="80a99a8e-fb62-4313-a07a-806f36458f24">
+        <bounds x="228" y="84" width="241" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="02d7de48-95e1-46af-bd42-a61a49271178" source="f67eadc1-b27c-4d62-8165-319797b368b9" target="4dd36f65-9daf-4a5e-9e7a-fcade88cf8e8" archimateRelationship="33c74883-5fc8-48e6-abc8-7c960abeb80c"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ca01271a-74fc-484b-ac9f-68d294884edf" source="f67eadc1-b27c-4d62-8165-319797b368b9" target="0f9f5a68-ff07-4b9b-aa62-2c624565b429" archimateRelationship="82553ea7-0ba8-4e81-a579-13e0bec64da9"/>
+        <sourceConnection xsi:type="archimate:Connection" id="9429a2b2-3f39-4439-9f0d-2157e55cd62c" source="f67eadc1-b27c-4d62-8165-319797b368b9" target="e2d0ff3c-d726-4fae-b588-9ade76c26004" archimateRelationship="3908b95a-ba84-4ac6-bb2f-6bb43280d875">
+          <bendpoint startX="120" startY="81" endX="-186" endY="-75"/>
+          <bendpoint startX="300" startY="81" endX="-6" endY="-75"/>
+        </sourceConnection>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="ee712900-d19c-44f4-ae2d-b6532e7624b7" archimateElement="850c5bb7-f0c1-45ba-871f-daa2fd9c4be3">
+        <bounds x="228" y="348" width="133" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="a4502aad-2d6e-4a08-a86b-fa02056267d5" source="ee712900-d19c-44f4-ae2d-b6532e7624b7" target="4dd36f65-9daf-4a5e-9e7a-fcade88cf8e8" archimateRelationship="c33cf13e-3c35-49a0-ac07-e06bef941711"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="4dd36f65-9daf-4a5e-9e7a-fcade88cf8e8" targetConnections="02d7de48-95e1-46af-bd42-a61a49271178 a4502aad-2d6e-4a08-a86b-fa02056267d5 315b1723-fa5d-40c1-aec1-26cd17688490" archimateElement="cf368aea-2632-472e-93fd-9283417f526a">
+        <bounds x="228" y="240" width="133" height="58"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="39ff1da1-3c22-4863-9610-d65f8a584ca3" archimateElement="cd190536-c093-4a49-99d6-a8cbb5de0876">
+        <bounds x="408" y="348" width="133" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="2ccb916a-302d-4c5d-912f-d18713e3fa1f" source="39ff1da1-3c22-4863-9610-d65f8a584ca3" target="0f9f5a68-ff07-4b9b-aa62-2c624565b429" archimateRelationship="4622db27-8f5e-4815-b434-d68e13d6fd4d"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="0f9f5a68-ff07-4b9b-aa62-2c624565b429" targetConnections="2ccb916a-302d-4c5d-912f-d18713e3fa1f ca01271a-74fc-484b-ac9f-68d294884edf 044ce3f5-ec8f-4da9-94c0-2eb9906cfe3e" archimateElement="8fce2f71-c778-48e6-8182-fc92696647d7">
+        <bounds x="408" y="240" width="133" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="c2cdd9e6-f17d-48d0-9ebe-1739f9c15967" archimateElement="487a932a-1d31-45a6-83d3-4a9a28854c90">
+        <bounds x="588" y="348" width="133" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="431b9008-c4cf-4aec-a156-376b4f36da49" source="c2cdd9e6-f17d-48d0-9ebe-1739f9c15967" target="e2d0ff3c-d726-4fae-b588-9ade76c26004" archimateRelationship="ab39ae42-6590-4c70-8d26-7393994c09ee"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="126f7817-c871-4533-a933-c90cd41ba10c" archimateElement="47712a4b-32c0-401d-887e-b659374a7166">
+        <bounds x="504" y="84" width="217" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="044ce3f5-ec8f-4da9-94c0-2eb9906cfe3e" source="126f7817-c871-4533-a933-c90cd41ba10c" target="0f9f5a68-ff07-4b9b-aa62-2c624565b429" archimateRelationship="90f0b202-39d7-4bf6-bedd-4c2d4d75451a"/>
+        <sourceConnection xsi:type="archimate:Connection" id="315b1723-fa5d-40c1-aec1-26cd17688490" source="126f7817-c871-4533-a933-c90cd41ba10c" target="4dd36f65-9daf-4a5e-9e7a-fcade88cf8e8" archimateRelationship="70325378-0b5d-491e-9467-3d31f6fb6da7">
+          <bendpoint startX="-108" startY="105" endX="210" endY="-53"/>
+          <bendpoint startX="-288" startY="105" endX="30" endY="-53"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="305a0845-349c-4cbc-a8cd-51a53001abbc" source="126f7817-c871-4533-a933-c90cd41ba10c" target="e2d0ff3c-d726-4fae-b588-9ade76c26004" archimateRelationship="cd39cff2-f359-4c32-8d98-b9cd24e85278"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="e2d0ff3c-d726-4fae-b588-9ade76c26004" targetConnections="431b9008-c4cf-4aec-a156-376b4f36da49 9429a2b2-3f39-4439-9f0d-2157e55cd62c 305a0845-349c-4cbc-a8cd-51a53001abbc" archimateElement="0de99420-0252-4788-8732-ee96f9f5e8b9">
+        <bounds x="588" y="240" width="133" height="55"/>
+      </child>
+      <documentation>This diagram shows the general architecture of how trust is managed in TOOP and for which roles certificates need to be issued to ensure the secure operations of the network. Although the diagram shows just one &quot;Certificate Authority&quot; role there can be many actors that fulfill this role, as the issuing of certificates is not centrally managed. </documentation>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="SMP trust relations" id="8d9bd3f5-8e6a-47ea-b204-7977c8b47309">
+      <child xsi:type="archimate:DiagramObject" id="44792769-b118-4dd2-946a-825257b94090" archimateElement="807ead6b-5921-4901-85ba-5aec2455149c">
+        <bounds x="504" y="205" width="157" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="048fd95a-0100-4078-a994-a051636b4d5d" source="44792769-b118-4dd2-946a-825257b94090" target="aa37449a-0c0f-4951-8242-e35897b4ae01" archimateRelationship="b750d5ac-710f-44b7-8821-bfdaa2f3ef44"/>
+        <sourceConnection xsi:type="archimate:Connection" id="d65f3809-f2ad-471f-a1e0-6dafd7cdaed0" source="44792769-b118-4dd2-946a-825257b94090" target="e1ac229b-695b-4aee-9f3b-0e33ae5c7b77" archimateRelationship="cf8b7260-494b-471f-bfc1-b9e8189a6759"/>
+        <sourceConnection xsi:type="archimate:Connection" id="1e625478-31ff-493a-ac96-5a6241f5e2e6" source="44792769-b118-4dd2-946a-825257b94090" target="d36a22e0-f8e6-4d40-ae85-3d197725631c" archimateRelationship="72d95b66-6a86-46d0-b55a-c9c8fd549c31"/>
+        <sourceConnection xsi:type="archimate:Connection" id="f4c7cf65-9284-4bc5-82b3-75e62034a98f" source="44792769-b118-4dd2-946a-825257b94090" target="7691ad2a-3349-4fa7-9e16-4a74dac1951a" archimateRelationship="7f9a43c4-38c1-40ba-ada8-b1351ad5abf9"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="dfc90773-a5c5-4cc7-a4d6-8f51bd1d8399" archimateElement="40e6d34e-02c4-4b57-8af3-a3bfc8c89962">
+        <bounds x="720" y="300" width="157" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e8bae1d6-2bcc-49ad-bb35-2b410ef06369" source="dfc90773-a5c5-4cc7-a4d6-8f51bd1d8399" target="62f2534a-8d51-4628-86ee-7a062cc52bd3" archimateRelationship="61b2b7b0-2c9d-4bc3-9c47-097ec9c630e4"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="27305808-d21e-4ff9-92fc-e50649eb7d76" targetConnections="fc3910a7-2aff-4836-ad7d-88459a35193e" archimateElement="c96b9e24-98ca-466d-a2d2-84993b348d01">
+        <bounds x="720" y="120" width="157" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e2007b6d-cb59-439a-a38e-64d6433a7bea" source="27305808-d21e-4ff9-92fc-e50649eb7d76" target="aa37449a-0c0f-4951-8242-e35897b4ae01" archimateRelationship="f2903ebc-ce72-40b8-95f7-3c2c3f7392e6"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="e1ac229b-695b-4aee-9f3b-0e33ae5c7b77" targetConnections="b5eaf935-84aa-4ecb-ae79-a590ce08070c d65f3809-f2ad-471f-a1e0-6dafd7cdaed0 5a74aa6b-44c7-4aa7-963e-8545ecb1a979 5f11ccfa-5ee3-413c-8b64-e6765414eb69" archimateElement="013f493e-1497-459f-96e7-e31942157778">
+        <bounds x="504" y="301" width="157" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="62f2534a-8d51-4628-86ee-7a062cc52bd3" targetConnections="e8bae1d6-2bcc-49ad-bb35-2b410ef06369" archimateElement="46993d29-c622-4da9-a827-613b19e05632">
+        <bounds x="720" y="192" width="157" height="71"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5538b207-1d5c-49d8-806e-d61d8f141f0d" source="62f2534a-8d51-4628-86ee-7a062cc52bd3" target="e99f4b60-2dca-48dc-bb1c-8493d6f5d6f4" archimateRelationship="e8fa5e21-a7ef-40b0-90cb-01348f4baad2"/>
+        <sourceConnection xsi:type="archimate:Connection" id="fc3910a7-2aff-4836-ad7d-88459a35193e" source="62f2534a-8d51-4628-86ee-7a062cc52bd3" target="27305808-d21e-4ff9-92fc-e50649eb7d76" archimateRelationship="1eee23ab-85d7-448b-b91d-57acde471992"/>
+        <child xsi:type="archimate:DiagramObject" id="e99f4b60-2dca-48dc-bb1c-8493d6f5d6f4" targetConnections="5538b207-1d5c-49d8-806e-d61d8f141f0d" archimateElement="ac982ce3-98bb-468b-a594-1f4463e9babb">
+          <bounds x="12" y="36" width="133" height="25"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b5eaf935-84aa-4ecb-ae79-a590ce08070c" source="e99f4b60-2dca-48dc-bb1c-8493d6f5d6f4" target="e1ac229b-695b-4aee-9f3b-0e33ae5c7b77" archimateRelationship="ac09f3a3-c4a9-4e2b-b82b-b65d12b43a24"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="aa37449a-0c0f-4951-8242-e35897b4ae01" targetConnections="048fd95a-0100-4078-a994-a051636b4d5d e2007b6d-cb59-439a-a38e-64d6433a7bea" archimateElement="5039ff23-50cf-45d4-adba-913033c25087">
+        <bounds x="504" y="120" width="157" height="37"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="376530c0-30d9-4a10-a7b7-d77145f529eb" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49">
+        <bounds x="96" y="204" width="157" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="80b317cf-a791-4fb2-9ac6-7215ab300f0f" source="376530c0-30d9-4a10-a7b7-d77145f529eb" target="06d94da0-82a1-4e53-97db-b447659e56be" archimateRelationship="fb759bf5-b9f2-485f-84ec-95a6478d9ddb"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5a74aa6b-44c7-4aa7-963e-8545ecb1a979" source="376530c0-30d9-4a10-a7b7-d77145f529eb" target="e1ac229b-695b-4aee-9f3b-0e33ae5c7b77" archimateRelationship="90f3360e-3901-468f-b687-90a86c2ef36b">
+          <bendpoint startX="-6" startY="93" endX="-414" endY="-4"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="9b424bfc-c4b6-4efe-93bb-8bfdb55804ac" source="376530c0-30d9-4a10-a7b7-d77145f529eb" target="7691ad2a-3349-4fa7-9e16-4a74dac1951a" archimateRelationship="687ed250-82b7-4953-b2b7-c9bb6da15ce6"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="d36a22e0-f8e6-4d40-ae85-3d197725631c" targetConnections="1e625478-31ff-493a-ac96-5a6241f5e2e6" archimateElement="f32e715b-c735-4cf9-95d5-442183d6a78e">
+        <bounds x="300" y="120" width="157" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="3bcc8424-6043-4a9b-a60e-a2362effee76" source="d36a22e0-f8e6-4d40-ae85-3d197725631c" target="06d94da0-82a1-4e53-97db-b447659e56be" archimateRelationship="ecb67bbc-5c83-405a-8190-286df0169aa4"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="06d94da0-82a1-4e53-97db-b447659e56be" targetConnections="3bcc8424-6043-4a9b-a60e-a2362effee76 80b317cf-a791-4fb2-9ac6-7215ab300f0f" archimateElement="ff508064-92fe-4e22-af13-af192add8998">
+        <bounds x="96" y="120" width="157" height="37"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="7691ad2a-3349-4fa7-9e16-4a74dac1951a" targetConnections="f4c7cf65-9284-4bc5-82b3-75e62034a98f 9b424bfc-c4b6-4efe-93bb-8bfdb55804ac" archimateElement="00da5f43-6209-4b90-98b6-66f241f28bc1">
+        <bounds x="300" y="204" width="157" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5f11ccfa-5ee3-413c-8b64-e6765414eb69" source="7691ad2a-3349-4fa7-9e16-4a74dac1951a" target="e1ac229b-695b-4aee-9f3b-0e33ae5c7b77" archimateRelationship="fb5fa28b-f3fb-4ec8-91f1-e34aba0e184c"/>
+      </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Access Point trust relations" id="adf48000-69bf-4893-9c28-9872f7da95f1" viewpoint="application_usage">
+      <child xsi:type="archimate:DiagramObject" id="dda452c3-c4f9-4bec-9246-650feb186dfa" archimateElement="b7b2aa18-f4d7-4341-945c-03837cb989a6">
+        <bounds x="264" y="120" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="161d0868-1537-48ea-ae31-e5ed35ca3e18" source="dda452c3-c4f9-4bec-9246-650feb186dfa" target="6b155a4c-6e0e-4e84-9d42-e3e5dedc12b9" archimateRelationship="464c9909-07ca-414e-b01e-853fff1b4327"/>
+        <sourceConnection xsi:type="archimate:Connection" id="3bc3f137-5dbb-4f7d-9a18-8085bcce80a5" source="dda452c3-c4f9-4bec-9246-650feb186dfa" target="e553d70f-6763-46a0-8bc4-7f0c2fd20a78" archimateRelationship="5343b9e4-3bde-4405-bd5e-c9aee89f9406">
+          <bendpoint startY="165" endX="-168" endY="-3"/>
+        </sourceConnection>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="44f1c9b4-0967-4130-9d97-a362b7915229" archimateElement="7c846708-edd4-4a3a-afad-a711b21abeb4">
+        <bounds x="744" y="120" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5aeb69f0-3207-46c6-813f-86f3aadca82f" source="44f1c9b4-0967-4130-9d97-a362b7915229" target="6b155a4c-6e0e-4e84-9d42-e3e5dedc12b9" archimateRelationship="10de0df5-0d04-4aa6-b193-6e395117585f"/>
+        <sourceConnection xsi:type="archimate:Connection" id="dfe922fe-d8f2-4a3e-9f03-63ad5e6ee9f9" source="44f1c9b4-0967-4130-9d97-a362b7915229" target="e553d70f-6763-46a0-8bc4-7f0c2fd20a78" archimateRelationship="313ced4f-857f-4427-b01d-52500abdd37d">
+          <bendpoint startX="-12" startY="165" endX="300" endY="-3"/>
+        </sourceConnection>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="6b155a4c-6e0e-4e84-9d42-e3e5dedc12b9" targetConnections="8c2ba55d-4770-4678-ab8f-58eed7d7d2a7 f3d38985-0f53-4a3a-b57b-533eb88a5d18 5aeb69f0-3207-46c6-813f-86f3aadca82f 161d0868-1537-48ea-ae31-e5ed35ca3e18" archimateElement="1ff4e70e-c2a6-4571-b700-c56d647e574b">
+        <bounds x="432" y="120" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="6fb448f2-8e09-46d0-9a97-01bf3a59347b" archimateElement="c0b1a8e1-f208-4c52-ba6e-5b1831bd8ff8">
+        <bounds x="432" y="36" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8c2ba55d-4770-4678-ab8f-58eed7d7d2a7" source="6fb448f2-8e09-46d0-9a97-01bf3a59347b" target="6b155a4c-6e0e-4e84-9d42-e3e5dedc12b9" archimateRelationship="bdf4759c-2641-4287-90c3-a041ab95260d"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="e553d70f-6763-46a0-8bc4-7f0c2fd20a78" targetConnections="3b4aba1e-4cc4-413a-81c1-ce6ace836992 dfe922fe-d8f2-4a3e-9f03-63ad5e6ee9f9 3bc3f137-5dbb-4f7d-9a18-8085bcce80a5" archimateElement="b05b5406-553d-4861-9f0d-9dfdce3907fc">
+        <bounds x="432" y="288" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="1b27c6d6-5c32-4a1c-aa10-b6ec10548c1c" targetConnections="30e1bb1c-7d5c-4ebc-ab3a-46562c21dfbc" archimateElement="145becdc-6985-48c4-a520-a423ae80ec59">
+        <bounds x="432" y="204" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="3b4aba1e-4cc4-413a-81c1-ce6ace836992" source="1b27c6d6-5c32-4a1c-aa10-b6ec10548c1c" target="e553d70f-6763-46a0-8bc4-7f0c2fd20a78" archimateRelationship="a2a116ac-b8af-4f25-a83d-846812131d6a"/>
+        <sourceConnection xsi:type="archimate:Connection" id="f3d38985-0f53-4a3a-b57b-533eb88a5d18" source="1b27c6d6-5c32-4a1c-aa10-b6ec10548c1c" target="6b155a4c-6e0e-4e84-9d42-e3e5dedc12b9" archimateRelationship="643accf2-614c-4e47-924f-b988442de60e"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="ff514497-d485-4514-97f3-acd61e5509fa" archimateElement="108c2382-e2bf-4950-93ba-10e61c915592">
+        <bounds x="600" y="204" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="30e1bb1c-7d5c-4ebc-ab3a-46562c21dfbc" source="ff514497-d485-4514-97f3-acd61e5509fa" target="1b27c6d6-5c32-4a1c-aa10-b6ec10548c1c" archimateRelationship="571b3819-03f2-4bc1-83de-20730c99666d"/>
+      </child>
+    </element>
+  </folder>
+</archimate:model>


### PR DESCRIPTION
This commit contains the Archi file with my architecture diagrams. As agreed during The Hague meeting it contains two technology layer diagrams, one showing deployment of components and the other the needed network connection.
Also in this file are diagrams related to trust relations and trust management.