### PR TITLE
Update of my diagrams based on discussions during Brussels workshop

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,6 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# backup files
+*.bak

--- a/TOOP Architecture.archimate
+++ b/TOOP Architecture.archimate
@@ -36,6 +36,10 @@
     <element xsi:type="archimate:BusinessActor" name="Member State (copy)" id="ca3c1a83-d099-4a3c-b28f-8cc3bb8738b8"/>
     <element xsi:type="archimate:BusinessActor" name="TOOP Network Management" id="0077ac29-da6d-426c-90a0-51e987d5f202"/>
     <element xsi:type="archimate:BusinessProcess" name="Process evidence" id="8af6862d-cfee-417d-82d1-d92058948e4a"/>
+    <element xsi:type="archimate:BusinessActor" name="Member State" id="ead927f6-aada-4517-9de7-5dcb477a7e36"/>
+    <element xsi:type="archimate:BusinessActor" name="Competent Authority" id="77d30d3e-5889-4267-ac13-43ae42eec1d1"/>
+    <element xsi:type="archimate:BusinessActor" name="Member State" id="b84f65fc-b9ae-4104-bb70-8626630a4db8"/>
+    <element xsi:type="archimate:BusinessActor" name="National OOP Layer Provider" id="ad5945bc-e137-4d97-8af6-2a0752cd75d5"/>
   </folder>
   <folder name="Application" id="14ecd00d-adbb-4a53-8985-eb26c7380878" type="application">
     <element xsi:type="archimate:ApplicationComponent" name="Data Consumer System" id="c69264a3-6790-4058-8056-d7654ae77a75"/>
@@ -80,8 +84,19 @@
     <element xsi:type="archimate:DataObject" name="AS4 Receipt" id="b05b5406-553d-4861-9f0d-9dfdce3907fc"/>
     <element xsi:type="archimate:DataObject" name="AP Provider (DP) Certificate" id="145becdc-6985-48c4-a520-a423ae80ec59"/>
     <element xsi:type="archimate:DataObject" name="SMP Meta-data" id="108c2382-e2bf-4950-93ba-10e61c915592"/>
-    <element xsi:type="archimate:ApplicationComponent" name="AS Access Point (DC) (copy)" id="d919bb01-6f6e-4b59-88f1-8764638de3f4"/>
     <element xsi:type="archimate:DataObject" name="Signed meta-data (copy)" id="6ec3236f-3e73-4100-8e18-cd783f289ba6"/>
+    <element xsi:type="archimate:ApplicationComponent" name="TOOP Connector" id="b39dc60a-f0ea-48a2-afe5-35c284ad66ed"/>
+    <element xsi:type="archimate:ApplicationInterface" name="AS4" id="835ff675-a050-43e1-b604-bf34f420b4b4"/>
+    <element xsi:type="archimate:ApplicationInterface" name="AS4" id="02845e0f-b515-434b-acee-3cb30c0a38d5"/>
+    <element xsi:type="archimate:ApplicationInterface" name="Gateway back-end interface" id="9a9db724-b4cf-4cf5-83e4-dab836fac332"/>
+    <element xsi:type="archimate:ApplicationInterface" name="SMP registration interface" id="1a514cf5-70e0-49af-b794-9ef63c488161"/>
+    <element xsi:type="archimate:ApplicationInterface" name="SMP REST binding" id="d025299b-1e44-4c5c-8a92-46eceda4a5c5"/>
+    <element xsi:type="archimate:ApplicationInterface" name="SMP REST binding (copy)" id="7389032a-cc99-482b-a771-d84f92fd8119"/>
+    <element xsi:type="archimate:ApplicationInterface" name="REST query" id="c62c44e5-96f4-4823-b5d1-f0c8af91938a"/>
+    <element xsi:type="archimate:ApplicationInterface" name="SMP backend interface" id="885f43a3-57ff-4952-9f8b-146840faee3d"/>
+    <element xsi:type="archimate:ApplicationInterface" name="SMP backend interface (copy)" id="db1afbbe-2192-454f-8c54-7eb10861cc29"/>
+    <element xsi:type="archimate:ApplicationInterface" name="Gateway back-end interface (copy)" id="5d5f141b-0288-4b84-923f-b186eb23c67b"/>
+    <element xsi:type="archimate:ApplicationInterface" name="SSi" id="524e0622-8fa1-4688-998f-e378e2d50dd2"/>
   </folder>
   <folder name="Technology &amp; Physical" id="b37c3ce8-e970-4b27-9c32-83c4e3835745" type="technology">
     <element xsi:type="archimate:Node" name="Data Consumer System" id="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
@@ -117,6 +132,8 @@
     <element xsi:type="archimate:Node" name="DP's MS Trust List Server" id="819e7e8c-a185-4b7b-b205-940fefcfe408"/>
     <element xsi:type="archimate:Node" name="Access Point (DC) (copy)" id="f3fb9603-2d7a-4264-985f-ad75532816c9"/>
     <element xsi:type="archimate:SystemSoftware" name="AS4 Message Service Handler (copy)" id="70c184e2-dd66-4c98-8a3a-ec23190cff08"/>
+    <element xsi:type="archimate:TechnologyCollaboration" name="BDXL Implementation" id="16e6b406-99cd-4255-a1cc-6d6a8eb25fad"/>
+    <element xsi:type="archimate:Node" name="National OOP Layer System" id="cd615d71-a688-420d-afd6-4583cdfc32f4"/>
   </folder>
   <folder name="Motivation" id="e3dd0cb4-7b89-407a-9393-dbb9f347b6ec" type="motivation"/>
   <folder name="Implementation &amp; Migration" id="e6f65253-9459-48a8-a9f0-e9755b2e86fc" type="implementation_migration"/>
@@ -310,7 +327,6 @@
     <element xsi:type="archimate:ServingRelationship" id="424515ef-9f7d-470b-a218-c9f833280361" source="a46b13f6-899f-4651-bccd-67685ea0ab9d" target="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e"/>
     <element xsi:type="archimate:CompositionRelationship" id="d6e5ef8d-2ad7-4441-a8cb-8678d29ff483" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="cfadf0df-e7a6-4465-ba12-5ad6e915a525"/>
     <element xsi:type="archimate:CompositionRelationship" id="a03a7a78-4128-44ee-82fe-1197dbce4320" source="f3fb9603-2d7a-4264-985f-ad75532816c9" target="70c184e2-dd66-4c98-8a3a-ec23190cff08"/>
-    <element xsi:type="archimate:RealizationRelationship" id="e303b07f-6995-4e45-8000-39ca8a684984" source="f3fb9603-2d7a-4264-985f-ad75532816c9" target="d919bb01-6f6e-4b59-88f1-8764638de3f4"/>
     <element xsi:type="archimate:AccessRelationship" id="a8e0a53c-91f0-4691-8cab-0b7738e26827" source="727c636e-94a8-4af8-9af6-04bcec1e3143" target="030bea1c-c47c-49f8-89d6-8cd8d8929cf8" accessType="1"/>
     <element xsi:type="archimate:TriggeringRelationship" id="3e16413b-6f37-48ed-9564-c341b24d42cf" source="9c559689-3063-4980-ba54-6c6571fdfafa" target="6f2885ed-f6ec-421e-ac59-ac6e834612e0"/>
     <element xsi:type="archimate:TriggeringRelationship" id="b6e9ec44-6ff9-496c-a13b-bae24bce49b7" source="6f2885ed-f6ec-421e-ac59-ac6e834612e0" target="445db22c-cb8a-48ea-81c6-dbc99399fa91"/>
@@ -320,6 +336,42 @@
     <element xsi:type="archimate:CompositionRelationship" id="99f55014-b9d5-41ae-8fe4-a0059958bdaa" source="0d63a4ac-c4aa-40ff-8653-14d682a5531f" target="8af6862d-cfee-417d-82d1-d92058948e4a"/>
     <element xsi:type="archimate:TriggeringRelationship" id="98bda3f4-aebd-4562-947a-b530add99542" source="445db22c-cb8a-48ea-81c6-dbc99399fa91" target="6bc58486-8d4c-49ae-acf9-5113c4688d0a"/>
     <element xsi:type="archimate:TriggeringRelationship" id="6170adab-7381-4bfb-8bc0-b0e0d66af935" source="6bc58486-8d4c-49ae-acf9-5113c4688d0a" target="8af6862d-cfee-417d-82d1-d92058948e4a"/>
+    <element xsi:type="archimate:CompositionRelationship" id="590cb032-5e90-43cf-a05e-46eaa0beefcc" source="0984a188-6642-400c-a42f-20277624eee9" target="b39dc60a-f0ea-48a2-afe5-35c284ad66ed"/>
+    <element xsi:type="archimate:CompositionRelationship" id="96ac082a-4934-4e40-836a-8ad4ef304e95" source="16e6b406-99cd-4255-a1cc-6d6a8eb25fad" target="98f08e2a-55bb-4cf3-88f8-a72c328068e1"/>
+    <element xsi:type="archimate:CompositionRelationship" id="f6b64b03-3d7d-4252-b62f-8eda3a01958a" source="16e6b406-99cd-4255-a1cc-6d6a8eb25fad" target="8532f211-fbcb-4255-a32d-91871c7336be"/>
+    <element xsi:type="archimate:RealizationRelationship" id="a519c4a0-7f3d-4469-bb60-7d1404fa8ef0" source="16e6b406-99cd-4255-a1cc-6d6a8eb25fad" target="40e6d34e-02c4-4b57-8af3-a3bfc8c89962"/>
+    <element xsi:type="archimate:ServingRelationship" id="91467111-4dc4-4b4d-9138-4328809f18b3" source="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
+    <element xsi:type="archimate:RealizationRelationship" id="aef2d174-8f6c-4ec4-bb5e-6ead3a646ff9" source="cd615d71-a688-420d-afd6-4583cdfc32f4" target="b39dc60a-f0ea-48a2-afe5-35c284ad66ed"/>
+    <element xsi:type="archimate:ServingRelationship" id="4a660fa0-4e8f-431a-a526-0a5fe5523f1a" source="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d" target="cd615d71-a688-420d-afd6-4583cdfc32f4"/>
+    <element xsi:type="archimate:ServingRelationship" id="b5ad019f-315d-47e7-8c45-7f6f38f6b57d" source="ca49e61c-53cc-4599-b5fd-f30b80485328" target="cd615d71-a688-420d-afd6-4583cdfc32f4"/>
+    <element xsi:type="archimate:ServingRelationship" id="fe52d39f-721d-4207-8765-f42b54d38750" source="cd615d71-a688-420d-afd6-4583cdfc32f4" target="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e"/>
+    <element xsi:type="archimate:ServingRelationship" id="ce8340df-c3fc-4a8d-9987-b2f1dff90bcf" source="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349" target="cd615d71-a688-420d-afd6-4583cdfc32f4"/>
+    <element xsi:type="archimate:CompositionRelationship" id="06652625-b173-41c6-83a4-d51177cfa659" source="b7b2aa18-f4d7-4341-945c-03837cb989a6" target="835ff675-a050-43e1-b604-bf34f420b4b4"/>
+    <element xsi:type="archimate:CompositionRelationship" id="4c4c61ca-522d-4c69-a239-b7e3a4b481ed" source="7c846708-edd4-4a3a-afad-a711b21abeb4" target="02845e0f-b515-434b-acee-3cb30c0a38d5"/>
+    <element xsi:type="archimate:ServingRelationship" id="ae70350c-af50-4e6d-9063-dde12aa28cad" source="02845e0f-b515-434b-acee-3cb30c0a38d5" target="b7b2aa18-f4d7-4341-945c-03837cb989a6"/>
+    <element xsi:type="archimate:ServingRelationship" id="ad7aeacf-4597-4016-8f4d-18e840290654" source="835ff675-a050-43e1-b604-bf34f420b4b4" target="7c846708-edd4-4a3a-afad-a711b21abeb4"/>
+    <element xsi:type="archimate:CompositionRelationship" id="c9b7f6ce-d6ad-4680-8ea6-10c7ea24e8f5" source="b7b2aa18-f4d7-4341-945c-03837cb989a6" target="9a9db724-b4cf-4cf5-83e4-dab836fac332"/>
+    <element xsi:type="archimate:ServingRelationship" id="33626729-1190-4f6e-b71e-1f475b639a6d" source="9a9db724-b4cf-4cf5-83e4-dab836fac332" target="1480bf3c-d41d-4fea-827b-9ef9f79e6f49"/>
+    <element xsi:type="archimate:CompositionRelationship" id="d2f13c19-7c1c-4bce-99c1-c48fa70abb1a" source="40e6d34e-02c4-4b57-8af3-a3bfc8c89962" target="1a514cf5-70e0-49af-b794-9ef63c488161"/>
+    <element xsi:type="archimate:ServingRelationship" id="82fb773e-adcc-4992-b9c0-ec9da83600ba" source="1a514cf5-70e0-49af-b794-9ef63c488161" target="9dc22627-f969-46c8-ac76-9f1ac9b35767"/>
+    <element xsi:type="archimate:ServingRelationship" id="989c24da-5eea-45fb-9700-84160bc24552" source="1a514cf5-70e0-49af-b794-9ef63c488161" target="2cc22b82-8760-46b4-80cb-118fb3cb04ee"/>
+    <element xsi:type="archimate:CompositionRelationship" id="8ffa6c14-acbc-4d8e-bd8b-62a44994bb82" source="9dc22627-f969-46c8-ac76-9f1ac9b35767" target="d025299b-1e44-4c5c-8a92-46eceda4a5c5"/>
+    <element xsi:type="archimate:CompositionRelationship" id="6d237ab5-76b1-4476-b103-6b13be7e111e" source="2cc22b82-8760-46b4-80cb-118fb3cb04ee" target="7389032a-cc99-482b-a771-d84f92fd8119"/>
+    <element xsi:type="archimate:ServingRelationship" id="8c61761f-36e7-41a5-92ca-9dc20b1fc934" source="d025299b-1e44-4c5c-8a92-46eceda4a5c5" target="83a086f5-68c0-475d-88e8-c53fc033a533"/>
+    <element xsi:type="archimate:ServingRelationship" id="71a58fc5-548d-42d7-bd03-d6f593b582a6" source="7389032a-cc99-482b-a771-d84f92fd8119" target="83a086f5-68c0-475d-88e8-c53fc033a533"/>
+    <element xsi:type="archimate:ServingRelationship" id="1bb82133-972d-42be-a0fc-21c398424af0" source="7389032a-cc99-482b-a771-d84f92fd8119" target="b39dc60a-f0ea-48a2-afe5-35c284ad66ed"/>
+    <element xsi:type="archimate:ServingRelationship" id="09577d17-e481-4b1a-903a-7999a077b002" source="d025299b-1e44-4c5c-8a92-46eceda4a5c5" target="1480bf3c-d41d-4fea-827b-9ef9f79e6f49"/>
+    <element xsi:type="archimate:CompositionRelationship" id="9c40fea9-bda0-4ab6-9802-98600c801a46" source="83a086f5-68c0-475d-88e8-c53fc033a533" target="c62c44e5-96f4-4823-b5d1-f0c8af91938a"/>
+    <element xsi:type="archimate:ServingRelationship" id="cbe943d0-243b-4802-b73b-ea9e5942ceff" source="c62c44e5-96f4-4823-b5d1-f0c8af91938a" target="1480bf3c-d41d-4fea-827b-9ef9f79e6f49"/>
+    <element xsi:type="archimate:CompositionRelationship" id="8815aa98-d51a-4b9c-ab71-3eb2eee94558" source="9dc22627-f969-46c8-ac76-9f1ac9b35767" target="885f43a3-57ff-4952-9f8b-146840faee3d"/>
+    <element xsi:type="archimate:ServingRelationship" id="a24ea6e6-04e1-4269-ba3e-10c4f06faefe" source="885f43a3-57ff-4952-9f8b-146840faee3d" target="b39dc60a-f0ea-48a2-afe5-35c284ad66ed"/>
+    <element xsi:type="archimate:CompositionRelationship" id="3da7936f-6219-4b92-b91e-963e7d0ee505" source="2cc22b82-8760-46b4-80cb-118fb3cb04ee" target="db1afbbe-2192-454f-8c54-7eb10861cc29"/>
+    <element xsi:type="archimate:ServingRelationship" id="03081380-6feb-4459-813c-40df0f4d4be1" source="db1afbbe-2192-454f-8c54-7eb10861cc29" target="1480bf3c-d41d-4fea-827b-9ef9f79e6f49"/>
+    <element xsi:type="archimate:CompositionRelationship" id="519cb351-5dfc-4e2e-84cc-901bc0682ae2" source="7c846708-edd4-4a3a-afad-a711b21abeb4" target="5d5f141b-0288-4b84-923f-b186eb23c67b"/>
+    <element xsi:type="archimate:ServingRelationship" id="e8aeb9c9-677c-4e53-a466-5b1ec18d933a" source="5d5f141b-0288-4b84-923f-b186eb23c67b" target="b39dc60a-f0ea-48a2-afe5-35c284ad66ed"/>
+    <element xsi:type="archimate:CompositionRelationship" id="28c76209-3507-4429-a9dd-d9da1da7c400" source="5647d2da-812c-4a0f-af6e-bac94daa4aeb" target="524e0622-8fa1-4688-998f-e378e2d50dd2"/>
+    <element xsi:type="archimate:ServingRelationship" id="6d569d38-6a65-486e-9624-ea19776a3b5a" source="524e0622-8fa1-4688-998f-e378e2d50dd2" target="b39dc60a-f0ea-48a2-afe5-35c284ad66ed"/>
+    <element xsi:type="archimate:ServingRelationship" id="bd03205a-e3b7-40e5-9764-3096d03674ab" source="524e0622-8fa1-4688-998f-e378e2d50dd2" target="1480bf3c-d41d-4fea-827b-9ef9f79e6f49"/>
   </folder>
   <folder name="Views" id="6858a5da-9c29-42e4-b91f-7737960e8c81" type="diagrams">
     <element xsi:type="archimate:ArchimateDiagramModel" name="Using eDelivery for information exchange" id="a8345071-4aee-4bf1-bb65-64a973ab97ad" viewpoint="business_process_cooperation">
@@ -745,8 +797,127 @@
       </child>
     </element>
     <element xsi:type="archimate:ArchimateDiagramModel" name="Deployment topology #1" id="9f0ecd93-71c9-4fc3-b3b5-cb3422874279">
+      <child xsi:type="archimate:DiagramObject" id="1ac60665-620a-47ba-b078-b1ba87319186" fillColor="#fefc78" archimateElement="77d30d3e-5889-4267-ac13-43ae42eec1d1">
+        <bounds x="1476" y="120" width="309" height="1092"/>
+        <child xsi:type="archimate:DiagramObject" id="4cbbb745-e6ea-4aee-977d-2178183f4ec2" targetConnections="a8e3b84c-e756-4133-9d36-ab930d551cc0 7a3a94ec-ad77-4226-83c0-b2a8ca1c7fbc 01b72cc3-d955-4da8-8b63-bd56448f9847 b14bb356-0b52-4c71-b0fa-ea36f0d27070 70c94ee9-a972-4c1b-9235-130ca7751371" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
+          <bounds x="36" y="468" width="242" height="271"/>
+          <sourceConnection xsi:type="archimate:Connection" id="5a839017-abee-4fd2-a366-bdcc4915c4fe" source="4cbbb745-e6ea-4aee-977d-2178183f4ec2" target="72327a87-82a9-4f3f-98db-1c358ab5b6df" archimateRelationship="fec9ce18-5dfb-4483-b947-1d4dd4709b45"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="72327a87-82a9-4f3f-98db-1c358ab5b6df" targetConnections="5a839017-abee-4fd2-a366-bdcc4915c4fe" archimateElement="0984a188-6642-400c-a42f-20277624eee9" type="1">
+          <bounds x="35" y="324" width="242" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="614a3b2d-e223-4036-824f-6ea2867dd0b0" source="72327a87-82a9-4f3f-98db-1c358ab5b6df" target="aee9c5d3-02ed-40b0-868a-72c9780983b0" archimateRelationship="590cb032-5e90-43cf-a05e-46eaa0beefcc"/>
+          <child xsi:type="archimate:DiagramObject" id="aee9c5d3-02ed-40b0-868a-72c9780983b0" targetConnections="614a3b2d-e223-4036-824f-6ea2867dd0b0" archimateElement="b39dc60a-f0ea-48a2-afe5-35c284ad66ed" type="1">
+            <bounds x="24" y="36" width="189" height="52"/>
+          </child>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="f99d4466-1ad6-4e71-8e62-dfd23432c0d3" fillColor="#fefc78" archimateElement="ead927f6-aada-4517-9de7-5dcb477a7e36">
+        <bounds x="1128" y="120" width="309" height="1092"/>
+        <child xsi:type="archimate:DiagramObject" id="0d9cde6f-9382-479a-90d5-5515d57636c8" targetConnections="6d91fde9-7faf-4783-a5f4-3500ca5de394" archimateElement="197d58a5-2131-41e0-8ec3-37bc46ed9b3d" type="1">
+          <bounds x="59" y="63" width="193" height="44"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="ae4559fc-cf9a-47a8-8b71-4b23a916c468" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
+          <bounds x="59" y="144" width="193" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="722992ef-c758-4f34-92d7-31afeb047c65" source="ae4559fc-cf9a-47a8-8b71-4b23a916c468" target="fd503229-02f9-40f7-aeaa-5bb72030a899" archimateRelationship="b85300bf-77ed-49c7-84a8-011be915cee2"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a9d606af-1e06-41f5-887f-36f8fbfade49" source="ae4559fc-cf9a-47a8-8b71-4b23a916c468" target="322d2fa3-56ad-43e4-96e3-f64f733ed393" archimateRelationship="885e9e6f-9da6-4924-8aaf-d8c5ab20552b"/>
+          <child xsi:type="archimate:DiagramObject" id="fd503229-02f9-40f7-aeaa-5bb72030a899" targetConnections="722992ef-c758-4f34-92d7-31afeb047c65" archimateElement="68e59636-1f53-4336-9cfd-64fa6acae825">
+            <bounds x="14" y="40" width="151" height="55"/>
+            <sourceConnection xsi:type="archimate:Connection" id="6d91fde9-7faf-4783-a5f4-3500ca5de394" source="fd503229-02f9-40f7-aeaa-5bb72030a899" target="0d9cde6f-9382-479a-90d5-5515d57636c8" archimateRelationship="caab7f6b-ecb8-4257-85ef-bbff50ef681b"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="2da9702d-601c-44de-9b5f-8ca13b2ce338" targetConnections="b4a92e65-f269-4400-9519-05a1dc26d63b" archimateElement="9dc22627-f969-46c8-ac76-9f1ac9b35767" type="1">
+          <bounds x="60" y="600" width="194" height="43"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="039e3b6f-93ce-418e-8c67-f7d608b9bab3" targetConnections="88994f40-85e0-4745-850b-0816b5fe1bed" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
+          <bounds x="59" y="682" width="194" height="103"/>
+          <sourceConnection xsi:type="archimate:Connection" id="14b33f6c-8fbb-4b98-ab69-c813a1b57aca" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="454f2fd3-e258-4bc8-95d6-a5cfb9c4cdd1" archimateRelationship="dd6d220f-2e28-4568-9b32-05078dd07d50"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a8e3b84c-e756-4133-9d36-ab930d551cc0" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="ce7896f2-7830-4829-bc08-5d822b5ac10b"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b4a92e65-f269-4400-9519-05a1dc26d63b" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="2da9702d-601c-44de-9b5f-8ca13b2ce338" archimateRelationship="0bef2725-e92f-4ade-887e-3bd76eab034c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b52af52d-d20e-430b-a883-a49a5acb2f6b" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="1a65f425-6273-4339-badf-15bc2122b7fa">
+            <bendpoint startX="-168" endX="876" endY="142"/>
+            <bendpoint startX="-168" startY="-72" endX="876" endY="70"/>
+            <bendpoint startX="-528" startY="-72" endX="516" endY="70"/>
+            <bendpoint startX="-528" startY="-144" endX="516" endY="-2"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="260d4613-78a3-4e5b-ae76-097bd7787447" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" archimateRelationship="3de150e4-3c9e-45ad-9c44-fc2dccf967a3">
+            <bendpoint startX="-132" startY="-13" endX="210" endY="147"/>
+            <bendpoint startX="-132" startY="-169" endX="210" endY="-9"/>
+          </sourceConnection>
+          <child xsi:type="archimate:DiagramObject" id="454f2fd3-e258-4bc8-95d6-a5cfb9c4cdd1" targetConnections="14b33f6c-8fbb-4b98-ab69-c813a1b57aca" archimateElement="1a8879f8-06ce-4925-93ab-ff2222e347aa">
+            <bounds x="21" y="41" width="133" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="88af58c4-9adf-4338-a54b-352b34d04b76" targetConnections="ded17a8a-f591-460f-8b90-be187b7e5fa3" archimateElement="7c846708-edd4-4a3a-afad-a711b21abeb4" type="1">
+          <bounds x="59" y="871" width="194" height="55"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="ac0da59a-a9b6-447a-a997-b63e18573dc5" targetConnections="d55b5255-5a38-4c3d-924c-102ceb0070ff" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
+          <bounds x="59" y="950" width="194" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="8b1528bb-d013-4d6c-abc8-c3ce341659b5" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="9404da78-8721-4fa9-b367-b99217b83f22" archimateRelationship="67b2f7a1-c01c-464b-8caa-b4a9744f35ae"/>
+          <sourceConnection xsi:type="archimate:Connection" id="7a3a94ec-ad77-4226-83c0-b2a8ca1c7fbc" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="59d8bd29-7642-49a0-9c2f-48b13fa3fdfc">
+            <bendpoint startX="375" startY="4" endX="-1" endY="406"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="ded17a8a-f591-460f-8b90-be187b7e5fa3" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="88af58c4-9adf-4338-a54b-352b34d04b76" archimateRelationship="bf3a3e9b-d6d1-4989-8ef7-021d1f136913"/>
+          <sourceConnection xsi:type="archimate:Connection" id="88c62c2e-8249-43d0-b8a7-86b4ac12694e" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" archimateRelationship="0e0d90ea-f06a-414b-9eab-4e425f96d110"/>
+          <child xsi:type="archimate:DiagramObject" id="9404da78-8721-4fa9-b367-b99217b83f22" targetConnections="8b1528bb-d013-4d6c-abc8-c3ce341659b5" archimateElement="51eacaa9-ed7b-4307-915c-05a114b2a19d">
+            <bounds x="21" y="41" width="141" height="55"/>
+          </child>
+        </child>
+      </child>
       <child xsi:type="archimate:DiagramObject" id="63ecb780-4b72-48f7-8e69-969345a6f3f4" fillColor="#fefc78" archimateElement="0077ac29-da6d-426c-90a0-51e987d5f202">
         <bounds x="780" y="120" width="309" height="1092"/>
+        <child xsi:type="archimate:DiagramObject" id="e1337d67-2fc2-4f98-b87e-446c41cd22a5" archimateElement="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349">
+          <bounds x="62" y="308" width="204" height="109"/>
+          <sourceConnection xsi:type="archimate:Connection" id="e82ecd83-1ab0-4fd7-9d1b-d008d447df6f" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="12a02288-f1ba-4dc8-803a-dd87c10bdd00" archimateRelationship="e08143cb-a72b-4f01-b442-a8c905603be7"/>
+          <sourceConnection xsi:type="archimate:Connection" id="98c0b577-10d7-4b50-a784-f587880399ea" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="289762f7-5dbc-47d6-b151-929e3c48c7a1" archimateRelationship="3dfc3dbf-5711-45b6-930a-0dc44678676a"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b14bb356-0b52-4c71-b0fa-ea36f0d27070" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="9102c6a7-d07f-4de0-94d7-273bb7bca236">
+            <bendpoint startX="160" startY="-2" endX="-528" endY="-230"/>
+            <bendpoint startX="520" startY="154" endX="-168" endY="-74"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="8202fcb6-2a06-42ed-acd7-5092c9c7e32b" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="5ad8159f-f033-40fd-977d-34f2694d728b">
+            <bendpoint startX="-176" startY="-2" endX="528" endY="-218"/>
+            <bendpoint startX="-536" startY="130" endX="168" endY="-86"/>
+          </sourceConnection>
+          <child xsi:type="archimate:DiagramObject" id="289762f7-5dbc-47d6-b151-929e3c48c7a1" targetConnections="98c0b577-10d7-4b50-a784-f587880399ea" archimateElement="fede8dba-b24e-4347-9487-e9901da917f9">
+            <bounds x="22" y="52" width="148" height="47"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="12a02288-f1ba-4dc8-803a-dd87c10bdd00" targetConnections="e82ecd83-1ab0-4fd7-9d1b-d008d447df6f" archimateElement="5647d2da-812c-4a0f-af6e-bac94daa4aeb" type="1">
+          <bounds x="60" y="216" width="204" height="55"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" targetConnections="7d504256-873f-49e8-ba1c-7203b9ba1c14 a30f308a-bead-4e37-94e0-ed6d70714fc7" archimateElement="8532f211-fbcb-4255-a32d-91871c7336be">
+          <bounds x="60" y="924" width="205" height="60"/>
+          <sourceConnection xsi:type="archimate:Connection" id="3e3c38fa-20f6-451d-b15d-2451986cff47" source="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="b8077982-bc5b-42e6-baad-9a371e82443c">
+            <bendpoint startX="-185" startY="7" endX="516" endY="370"/>
+            <bendpoint startX="-185" startY="-101" endX="516" endY="262"/>
+            <bendpoint startX="-641" startY="-101" endX="60" endY="262"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="70c94ee9-a972-4c1b-9235-130ca7751371" source="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="604120c2-2acc-4b05-a43d-c707a73ad5dc">
+            <bendpoint startX="163" startY="7" endX="-528" endY="358"/>
+            <bendpoint startX="163" startY="-101" endX="-528" endY="250"/>
+            <bendpoint startX="619" startY="-101" endX="-72" endY="250"/>
+          </sourceConnection>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="22f86c10-9ab5-46f0-937a-5b6f932871d5" targetConnections="970908be-d9bf-4c6a-b980-589ffadedaaa" archimateElement="98f08e2a-55bb-4cf3-88f8-a72c328068e1">
+          <bounds x="60" y="720" width="205" height="100"/>
+          <sourceConnection xsi:type="archimate:Connection" id="1e49dc22-018d-44fc-b41c-6ffcd057e7d3" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="521a3ab7-857d-4319-b150-848d7e62010a" archimateRelationship="f4d55798-6548-4f2b-8a36-dfb103680504"/>
+          <sourceConnection xsi:type="archimate:Connection" id="496da764-66cb-4cc2-bad1-b2c5b2c3f094" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="7551b95a-b261-4058-8d05-12e2b1b33b70" archimateRelationship="dbe8aa22-0fa9-4cf4-9585-78e68a698731"/>
+          <sourceConnection xsi:type="archimate:Connection" id="88994f40-85e0-4745-850b-0816b5fe1bed" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="039e3b6f-93ce-418e-8c67-f7d608b9bab3" archimateRelationship="b1837450-f7fb-4eb5-8d35-95206ec0ad1c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="7d504256-873f-49e8-ba1c-7203b9ba1c14" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" archimateRelationship="4ccd9580-1076-4ab8-9e7c-51b10d00aa48">
+            <bendpoint startX="-65" startY="107" endX="-65" endY="-77"/>
+          </sourceConnection>
+          <child xsi:type="archimate:DiagramObject" id="521a3ab7-857d-4319-b150-848d7e62010a" targetConnections="1e49dc22-018d-44fc-b41c-6ffcd057e7d3" archimateElement="e573296a-1aac-4c71-871c-1baf2417c996">
+            <bounds x="17" y="45" width="152" height="47"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="f3d1651e-c310-42bb-b5ec-247db8dffd2c" archimateElement="16e6b406-99cd-4255-a1cc-6d6a8eb25fad">
+          <bounds x="108" y="852" width="72" height="40"/>
+          <sourceConnection xsi:type="archimate:Connection" id="970908be-d9bf-4c6a-b980-589ffadedaaa" source="f3d1651e-c310-42bb-b5ec-247db8dffd2c" target="22f86c10-9ab5-46f0-937a-5b6f932871d5" archimateRelationship="96ac082a-4934-4e40-836a-8ad4ef304e95"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a30f308a-bead-4e37-94e0-ed6d70714fc7" source="f3d1651e-c310-42bb-b5ec-247db8dffd2c" target="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" archimateRelationship="f6b64b03-3d7d-4252-b62f-8eda3a01958a"/>
+          <sourceConnection xsi:type="archimate:Connection" id="84259349-92a7-4a80-a16e-e125544c72ed" source="f3d1651e-c310-42bb-b5ec-247db8dffd2c" target="04d1a2f0-4739-4615-93d2-e711781d9697" archimateRelationship="a519c4a0-7f3d-4469-bb60-7d1404fa8ef0"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="04d1a2f0-4739-4615-93d2-e711781d9697" targetConnections="84259349-92a7-4a80-a16e-e125544c72ed" archimateElement="40e6d34e-02c4-4b57-8af3-a3bfc8c89962" type="1">
+          <bounds x="216" y="852" width="84" height="40"/>
+        </child>
       </child>
       <child xsi:type="archimate:DiagramObject" id="bf37c088-c83f-402a-9b52-face97ad58d0" fillColor="#fefc78" archimateElement="2c9f4633-1900-40f9-9ea1-3758509a1381">
         <bounds x="432" y="120" width="309" height="1093"/>
@@ -759,7 +930,7 @@
           <sourceConnection xsi:type="archimate:Connection" id="d2481ae9-a94a-4dc6-a1df-4719e46e21ca" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="de9260ad-5f12-48cf-a893-56a0aa37e98a" archimateRelationship="c63e1909-e2fe-4516-b642-d6749c9ad79c"/>
           <sourceConnection xsi:type="archimate:Connection" id="d55b5255-5a38-4c3d-924c-102ceb0070ff" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="ac0da59a-a9b6-447a-a997-b63e18573dc5" archimateRelationship="bce71955-7d5f-4f3d-a47c-a5b0b5af71d8"/>
           <sourceConnection xsi:type="archimate:Connection" id="79075b5b-919e-421c-8e84-12e0193315fc" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="254d9661-8126-4963-8d40-e57116fa4186">
-            <bendpoint startX="-356" startY="5" endX="-14" endY="360"/>
+            <bendpoint startX="-360" startY="8" endX="-12" endY="430"/>
           </sourceConnection>
           <child xsi:type="archimate:DiagramObject" id="de9260ad-5f12-48cf-a893-56a0aa37e98a" targetConnections="d2481ae9-a94a-4dc6-a1df-4719e46e21ca" archimateElement="cc875beb-f4ff-4952-9600-5eae35fb0d10">
             <bounds x="21" y="41" width="141" height="55"/>
@@ -771,8 +942,8 @@
           <sourceConnection xsi:type="archimate:Connection" id="a1936d07-6c4c-457c-895c-876da16d7561" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="00c4a55a-5ec6-42e1-91fc-de97c090c9ec"/>
           <sourceConnection xsi:type="archimate:Connection" id="6cb388b0-1f6f-4428-b5fd-f7b6b53b4d97" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="a9247692-5ec4-4f7d-b797-9f6d750eef2c" archimateRelationship="6652b746-6c44-479c-b3e9-5f901199d7ef"/>
           <sourceConnection xsi:type="archimate:Connection" id="01b72cc3-d955-4da8-8b63-bd56448f9847" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="424515ef-9f7d-470b-a218-c9f833280361">
-            <bendpoint startX="502" startY="-39" endX="-574" endY="97"/>
-            <bendpoint startX="502" startY="-159" endX="-574" endY="-23"/>
+            <bendpoint startX="516" startY="-26" endX="-528" endY="106"/>
+            <bendpoint startX="516" startY="-146" endX="-528" endY="-14"/>
           </sourceConnection>
           <child xsi:type="archimate:DiagramObject" id="a9247692-5ec4-4f7d-b797-9f6d750eef2c" targetConnections="6cb388b0-1f6f-4428-b5fd-f7b6b53b4d97" archimateElement="8efc3e85-150e-4e1d-91f5-8989b1c5b89f">
             <bounds x="21" y="41" width="133" height="55"/>
@@ -793,39 +964,20 @@
       </child>
       <child xsi:type="archimate:DiagramObject" id="a60a31a5-c9b9-4e5d-ac1a-f5276b3ac997" fillColor="#fefc78" archimateElement="cfadf0df-e7a6-4465-ba12-5ad6e915a525">
         <bounds x="84" y="120" width="309" height="1093"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" targetConnections="cc3457cb-c306-4a3c-abec-c76682da886f 79075b5b-919e-421c-8e84-12e0193315fc a1936d07-6c4c-457c-895c-876da16d7561 b52af52d-d20e-430b-a883-a49a5acb2f6b 8202fcb6-2a06-42ed-acd7-5092c9c7e32b 2cdfbe62-9fb3-421d-bd23-f47f9b92b83a 3e3c38fa-20f6-451d-b15d-2451986cff47" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
-        <bounds x="107" y="572" width="274" height="271"/>
-        <sourceConnection xsi:type="archimate:Connection" id="5012fc94-bb3f-4169-bd3c-125c69d8476d" source="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" target="af1e1f82-d762-4e1c-b94c-28a68482a967" archimateRelationship="65eeae27-537c-48c0-9390-455f475c2800"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="af1e1f82-d762-4e1c-b94c-28a68482a967" targetConnections="5012fc94-bb3f-4169-bd3c-125c69d8476d" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75" type="1">
-        <bounds x="107" y="441" width="274" height="93"/>
-        <sourceConnection xsi:type="archimate:Connection" id="6f94354e-629a-4ae7-9a3f-5d38214b491e" source="af1e1f82-d762-4e1c-b94c-28a68482a967" target="5562e0e3-7aa7-470f-aa76-641ada75095d" archimateRelationship="8d84949c-da2f-456f-9c85-eb903765cea5"/>
-        <child xsi:type="archimate:DiagramObject" id="5562e0e3-7aa7-470f-aa76-641ada75095d" targetConnections="6f94354e-629a-4ae7-9a3f-5d38214b491e" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" type="1">
-          <bounds x="48" y="26" width="177" height="52"/>
+        <child xsi:type="archimate:DiagramObject" id="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" targetConnections="cc3457cb-c306-4a3c-abec-c76682da886f 79075b5b-919e-421c-8e84-12e0193315fc a1936d07-6c4c-457c-895c-876da16d7561 b52af52d-d20e-430b-a883-a49a5acb2f6b 2cdfbe62-9fb3-421d-bd23-f47f9b92b83a 3e3c38fa-20f6-451d-b15d-2451986cff47 8202fcb6-2a06-42ed-acd7-5092c9c7e32b" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
+          <bounds x="36" y="456" width="242" height="271"/>
+          <sourceConnection xsi:type="archimate:Connection" id="5012fc94-bb3f-4169-bd3c-125c69d8476d" source="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" target="af1e1f82-d762-4e1c-b94c-28a68482a967" archimateRelationship="65eeae27-537c-48c0-9390-455f475c2800"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="af1e1f82-d762-4e1c-b94c-28a68482a967" targetConnections="5012fc94-bb3f-4169-bd3c-125c69d8476d" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75" type="1">
+          <bounds x="36" y="312" width="242" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="6f94354e-629a-4ae7-9a3f-5d38214b491e" source="af1e1f82-d762-4e1c-b94c-28a68482a967" target="5562e0e3-7aa7-470f-aa76-641ada75095d" archimateRelationship="8d84949c-da2f-456f-9c85-eb903765cea5"/>
+          <child xsi:type="archimate:DiagramObject" id="5562e0e3-7aa7-470f-aa76-641ada75095d" targetConnections="6f94354e-629a-4ae7-9a3f-5d38214b491e" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" type="1">
+            <bounds x="24" y="36" width="189" height="52"/>
+          </child>
         </child>
       </child>
       <child xsi:type="archimate:DiagramObject" id="d0288160-d92d-4888-8bb4-7dfb83b2676f" targetConnections="23c76cfe-4519-4ee6-99aa-2300581faaf8" archimateElement="5e3cba4d-6785-4a6a-80e7-ccabcb45c0e3" type="1">
         <bounds x="492" y="180" width="193" height="44"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="12a02288-f1ba-4dc8-803a-dd87c10bdd00" targetConnections="e82ecd83-1ab0-4fd7-9d1b-d008d447df6f" archimateElement="5647d2da-812c-4a0f-af6e-bac94daa4aeb" type="1">
-        <bounds x="840" y="349" width="204" height="55"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="e1337d67-2fc2-4f98-b87e-446c41cd22a5" archimateElement="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349">
-        <bounds x="842" y="441" width="204" height="109"/>
-        <sourceConnection xsi:type="archimate:Connection" id="e82ecd83-1ab0-4fd7-9d1b-d008d447df6f" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="12a02288-f1ba-4dc8-803a-dd87c10bdd00" archimateRelationship="e08143cb-a72b-4f01-b442-a8c905603be7"/>
-        <sourceConnection xsi:type="archimate:Connection" id="98c0b577-10d7-4b50-a784-f587880399ea" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="289762f7-5dbc-47d6-b151-929e3c48c7a1" archimateRelationship="3dfc3dbf-5711-45b6-930a-0dc44678676a"/>
-        <sourceConnection xsi:type="archimate:Connection" id="8202fcb6-2a06-42ed-acd7-5092c9c7e32b" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="5ad8159f-f033-40fd-977d-34f2694d728b">
-          <bendpoint startX="-307" startY="16" endX="394" endY="-210"/>
-          <bendpoint startX="-296" startY="134" endX="391" endY="-98"/>
-        </sourceConnection>
-        <sourceConnection xsi:type="archimate:Connection" id="b14bb356-0b52-4c71-b0fa-ea36f0d27070" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="9102c6a7-d07f-4de0-94d7-273bb7bca236">
-          <bendpoint startX="409" startY="17" endX="-307" endY="-215"/>
-          <bendpoint startX="410" startY="142" endX="-306" endY="-90"/>
-        </sourceConnection>
-        <child xsi:type="archimate:DiagramObject" id="289762f7-5dbc-47d6-b151-929e3c48c7a1" targetConnections="98c0b577-10d7-4b50-a784-f587880399ea" archimateElement="fede8dba-b24e-4347-9487-e9901da917f9">
-          <bounds x="22" y="52" width="148" height="47"/>
-        </child>
       </child>
       <child xsi:type="archimate:DiagramObject" id="f99d35cb-eade-4648-9f73-718fa8155c97" targetConnections="7e680171-eb4e-4d4e-931a-8da5b30f10ca" archimateElement="83a086f5-68c0-475d-88e8-c53fc033a533" type="1">
         <bounds x="841" y="563" width="205" height="43"/>
@@ -839,83 +991,8 @@
           <bounds x="20" y="47" width="152" height="55"/>
         </child>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="22f86c10-9ab5-46f0-937a-5b6f932871d5" archimateElement="98f08e2a-55bb-4cf3-88f8-a72c328068e1">
-        <bounds x="840" y="850" width="205" height="100"/>
-        <sourceConnection xsi:type="archimate:Connection" id="1e49dc22-018d-44fc-b41c-6ffcd057e7d3" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="521a3ab7-857d-4319-b150-848d7e62010a" archimateRelationship="f4d55798-6548-4f2b-8a36-dfb103680504"/>
-        <sourceConnection xsi:type="archimate:Connection" id="496da764-66cb-4cc2-bad1-b2c5b2c3f094" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="7551b95a-b261-4058-8d05-12e2b1b33b70" archimateRelationship="dbe8aa22-0fa9-4cf4-9585-78e68a698731"/>
-        <sourceConnection xsi:type="archimate:Connection" id="88994f40-85e0-4745-850b-0816b5fe1bed" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="039e3b6f-93ce-418e-8c67-f7d608b9bab3" archimateRelationship="b1837450-f7fb-4eb5-8d35-95206ec0ad1c"/>
-        <sourceConnection xsi:type="archimate:Connection" id="7d504256-873f-49e8-ba1c-7203b9ba1c14" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" archimateRelationship="4ccd9580-1076-4ab8-9e7c-51b10d00aa48"/>
-        <child xsi:type="archimate:DiagramObject" id="521a3ab7-857d-4319-b150-848d7e62010a" targetConnections="1e49dc22-018d-44fc-b41c-6ffcd057e7d3" archimateElement="e573296a-1aac-4c71-871c-1baf2417c996">
-          <bounds x="17" y="45" width="152" height="47"/>
-        </child>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" targetConnections="7d504256-873f-49e8-ba1c-7203b9ba1c14" archimateElement="8532f211-fbcb-4255-a32d-91871c7336be">
-        <bounds x="840" y="972" width="205" height="78"/>
-        <sourceConnection xsi:type="archimate:Connection" id="3e3c38fa-20f6-451d-b15d-2451986cff47" source="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="b8077982-bc5b-42e6-baad-9a371e82443c">
-          <bendpoint startX="-627" startY="6" endX="61" endY="245"/>
-        </sourceConnection>
-        <sourceConnection xsi:type="archimate:Connection" id="70c94ee9-a972-4c1b-9235-130ca7751371" source="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="604120c2-2acc-4b05-a43d-c707a73ad5dc">
-          <bendpoint startX="657" endX="-80" endY="239"/>
-        </sourceConnection>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="039e3b6f-93ce-418e-8c67-f7d608b9bab3" targetConnections="88994f40-85e0-4745-850b-0816b5fe1bed" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
-        <bounds x="1211" y="803" width="194" height="103"/>
-        <sourceConnection xsi:type="archimate:Connection" id="14b33f6c-8fbb-4b98-ab69-c813a1b57aca" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="454f2fd3-e258-4bc8-95d6-a5cfb9c4cdd1" archimateRelationship="dd6d220f-2e28-4568-9b32-05078dd07d50"/>
-        <sourceConnection xsi:type="archimate:Connection" id="a8e3b84c-e756-4133-9d36-ab930d551cc0" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="ce7896f2-7830-4829-bc08-5d822b5ac10b"/>
-        <sourceConnection xsi:type="archimate:Connection" id="b4a92e65-f269-4400-9519-05a1dc26d63b" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="2da9702d-601c-44de-9b5f-8ca13b2ce338" archimateRelationship="0bef2725-e92f-4ade-887e-3bd76eab034c"/>
-        <sourceConnection xsi:type="archimate:Connection" id="b52af52d-d20e-430b-a883-a49a5acb2f6b" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="1a65f425-6273-4339-badf-15bc2122b7fa">
-          <bendpoint startX="-196" startY="-9" endX="878" endY="128"/>
-          <bendpoint startX="-196" startY="-81" endX="878" endY="56"/>
-          <bendpoint startX="-508" startY="-81" endX="566" endY="56"/>
-          <bendpoint startX="-508" startY="-141" endX="566" endY="-4"/>
-        </sourceConnection>
-        <sourceConnection xsi:type="archimate:Connection" id="260d4613-78a3-4e5b-ae76-097bd7787447" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" archimateRelationship="3de150e4-3c9e-45ad-9c44-fc2dccf967a3">
-          <bendpoint startX="-136" startY="-21" endX="236" endY="160"/>
-          <bendpoint startX="-136" startY="-189" endX="236" endY="-8"/>
-        </sourceConnection>
-        <child xsi:type="archimate:DiagramObject" id="454f2fd3-e258-4bc8-95d6-a5cfb9c4cdd1" targetConnections="14b33f6c-8fbb-4b98-ab69-c813a1b57aca" archimateElement="1a8879f8-06ce-4925-93ab-ff2222e347aa">
-          <bounds x="21" y="41" width="133" height="55"/>
-        </child>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="72327a87-82a9-4f3f-98db-1c358ab5b6df" targetConnections="5a839017-abee-4fd2-a366-bdcc4915c4fe" archimateElement="0984a188-6642-400c-a42f-20277624eee9" type="1">
-        <bounds x="1512" y="459" width="274" height="93"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="88af58c4-9adf-4338-a54b-352b34d04b76" targetConnections="ded17a8a-f591-460f-8b90-be187b7e5fa3" archimateElement="7c846708-edd4-4a3a-afad-a711b21abeb4" type="1">
-        <bounds x="1211" y="992" width="194" height="55"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="0d9cde6f-9382-479a-90d5-5515d57636c8" targetConnections="6d91fde9-7faf-4783-a5f4-3500ca5de394" archimateElement="197d58a5-2131-41e0-8ec3-37bc46ed9b3d" type="1">
-        <bounds x="1248" y="156" width="129" height="68"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="4cbbb745-e6ea-4aee-977d-2178183f4ec2" targetConnections="a8e3b84c-e756-4133-9d36-ab930d551cc0 7a3a94ec-ad77-4226-83c0-b2a8ca1c7fbc 01b72cc3-d955-4da8-8b63-bd56448f9847 b14bb356-0b52-4c71-b0fa-ea36f0d27070 70c94ee9-a972-4c1b-9235-130ca7751371" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
-        <bounds x="1512" y="588" width="274" height="271"/>
-        <sourceConnection xsi:type="archimate:Connection" id="5a839017-abee-4fd2-a366-bdcc4915c4fe" source="4cbbb745-e6ea-4aee-977d-2178183f4ec2" target="72327a87-82a9-4f3f-98db-1c358ab5b6df" archimateRelationship="fec9ce18-5dfb-4483-b947-1d4dd4709b45"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="ae4559fc-cf9a-47a8-8b71-4b23a916c468" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
-        <bounds x="1212" y="265" width="196" height="105"/>
-        <sourceConnection xsi:type="archimate:Connection" id="722992ef-c758-4f34-92d7-31afeb047c65" source="ae4559fc-cf9a-47a8-8b71-4b23a916c468" target="fd503229-02f9-40f7-aeaa-5bb72030a899" archimateRelationship="b85300bf-77ed-49c7-84a8-011be915cee2"/>
-        <sourceConnection xsi:type="archimate:Connection" id="a9d606af-1e06-41f5-887f-36f8fbfade49" source="ae4559fc-cf9a-47a8-8b71-4b23a916c468" target="322d2fa3-56ad-43e4-96e3-f64f733ed393" archimateRelationship="885e9e6f-9da6-4924-8aaf-d8c5ab20552b"/>
-        <child xsi:type="archimate:DiagramObject" id="fd503229-02f9-40f7-aeaa-5bb72030a899" targetConnections="722992ef-c758-4f34-92d7-31afeb047c65" archimateElement="68e59636-1f53-4336-9cfd-64fa6acae825">
-          <bounds x="14" y="40" width="151" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="6d91fde9-7faf-4783-a5f4-3500ca5de394" source="fd503229-02f9-40f7-aeaa-5bb72030a899" target="0d9cde6f-9382-479a-90d5-5515d57636c8" archimateRelationship="caab7f6b-ecb8-4257-85ef-bbff50ef681b"/>
-        </child>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="ac0da59a-a9b6-447a-a997-b63e18573dc5" targetConnections="d55b5255-5a38-4c3d-924c-102ceb0070ff" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
-        <bounds x="1211" y="1071" width="194" height="105"/>
-        <sourceConnection xsi:type="archimate:Connection" id="8b1528bb-d013-4d6c-abc8-c3ce341659b5" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="9404da78-8721-4fa9-b367-b99217b83f22" archimateRelationship="67b2f7a1-c01c-464b-8caa-b4a9744f35ae"/>
-        <sourceConnection xsi:type="archimate:Connection" id="7a3a94ec-ad77-4226-83c0-b2a8ca1c7fbc" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="59d8bd29-7642-49a0-9c2f-48b13fa3fdfc">
-          <bendpoint startX="338" startY="1" endX="-2" endY="356"/>
-        </sourceConnection>
-        <sourceConnection xsi:type="archimate:Connection" id="ded17a8a-f591-460f-8b90-be187b7e5fa3" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="88af58c4-9adf-4338-a54b-352b34d04b76" archimateRelationship="bf3a3e9b-d6d1-4989-8ef7-021d1f136913"/>
-        <sourceConnection xsi:type="archimate:Connection" id="88c62c2e-8249-43d0-b8a7-86b4ac12694e" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" archimateRelationship="0e0d90ea-f06a-414b-9eab-4e425f96d110"/>
-        <child xsi:type="archimate:DiagramObject" id="9404da78-8721-4fa9-b367-b99217b83f22" targetConnections="8b1528bb-d013-4d6c-abc8-c3ce341659b5" archimateElement="51eacaa9-ed7b-4307-915c-05a114b2a19d">
-          <bounds x="21" y="41" width="141" height="55"/>
-        </child>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="2da9702d-601c-44de-9b5f-8ca13b2ce338" targetConnections="b4a92e65-f269-4400-9519-05a1dc26d63b" archimateElement="9dc22627-f969-46c8-ac76-9f1ac9b35767" type="1">
-        <bounds x="1211" y="732" width="194" height="43"/>
-      </child>
-      <documentation>This diagram shows how the application components (or funtions, to be decided) defined in the ISA can be deployed to nodes in the technology architecture. As the SMP and AP can be deployed both centrally within a member state but also locally at a DC/DP this diagraim shows only one variant. 
-I have made the separation between BDXL back-end and the DNS server explicit in this diagram, but this means that is not easy to show, in a vsiually nice way, that the collaboration of both realize the BDXL application component. Maybe in this diagram the BDXL server should be just one node. That for normal operations however the DNS is used hower is important for realibility. </documentation>
+      <documentation>This diagram shows a variation of how the application components defined in the ISA can be deployed to nodes in the technology architecture. In this variant the SMP and AP are hosted by the Member State, i.e. shared by the Competent Authorities from that MS.
+</documentation>
     </element>
     <element xsi:type="archimate:ArchimateDiagramModel" name="Trust management" id="57970331-bf90-498c-8ad5-4248bdfcd5ba">
       <child xsi:type="archimate:DiagramObject" id="f67eadc1-b27c-4d62-8165-319797b368b9" archimateElement="80a99a8e-fb62-4313-a07a-806f36458f24">
@@ -1049,176 +1126,192 @@ I have made the separation between BDXL back-end and the DNS server explicit in 
       </child>
     </element>
     <element xsi:type="archimate:ArchimateDiagramModel" name="Deployment topology #2" id="d0921795-e2cd-4015-9de7-e07627e0ad95">
-      <child xsi:type="archimate:DiagramObject" id="4fa85870-ad58-42aa-8e8f-6bf5136bd79c" fillColor="#ffd478" archimateElement="cfadf0df-e7a6-4465-ba12-5ad6e915a525">
-        <bounds x="24" y="468" width="601" height="481"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="753d2117-9b05-427c-956a-a3073d41b6c8" archimateElement="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac">
-        <bounds x="1152" y="16" width="674" height="978"/>
-        <child xsi:type="archimate:DiagramObject" id="33a7600a-74b0-420b-892e-d7dde6f7440c" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
-          <bounds x="65" y="29" width="196" height="105"/>
-          <sourceConnection xsi:type="archimate:Connection" id="5ac8df1c-b092-49a9-a9b3-a078e688ef31" source="33a7600a-74b0-420b-892e-d7dde6f7440c" target="e447b35f-75dd-4355-b95e-246d3832dbb4" archimateRelationship="b85300bf-77ed-49c7-84a8-011be915cee2"/>
-          <sourceConnection xsi:type="archimate:Connection" id="02add9ad-9baf-44ff-9276-ea22a7ab9a18" source="33a7600a-74b0-420b-892e-d7dde6f7440c" target="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" archimateRelationship="885e9e6f-9da6-4924-8aaf-d8c5ab20552b"/>
-          <child xsi:type="archimate:DiagramObject" id="e447b35f-75dd-4355-b95e-246d3832dbb4" targetConnections="5ac8df1c-b092-49a9-a9b3-a078e688ef31" archimateElement="68e59636-1f53-4336-9cfd-64fa6acae825">
+      <child xsi:type="archimate:DiagramObject" id="bca95b86-8027-48a2-8f1f-b4c961765f03" fillColor="#fefc78" archimateElement="b84f65fc-b9ae-4104-bb70-8626630a4db8">
+        <bounds x="144" y="36" width="600" height="348"/>
+        <child xsi:type="archimate:DiagramObject" id="6fb1fe98-614c-4b29-93f0-982a8af99e02" targetConnections="7ab78d4c-fbd7-45fd-be95-ba07876019fe" archimateElement="5e3cba4d-6785-4a6a-80e7-ccabcb45c0e3" type="1">
+          <bounds x="384" y="60" width="193" height="44"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" targetConnections="19e21e5e-9972-4031-a758-39e24676d9e0" archimateElement="538aa797-e00b-442f-af83-9a8e7e85aadd">
+          <bounds x="384" y="144" width="193" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="8851b2c6-0270-4fec-92e1-e0365dcf8878" source="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" target="ed018181-fb3e-4d85-bb03-eb523a0c9fc2" archimateRelationship="49c8dabe-7bb4-4d12-b9c6-1cbd98f0c9a3"/>
+          <sourceConnection xsi:type="archimate:Connection" id="16b714b1-6862-4474-908c-7a82ba113637" source="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="3a2019bf-1f10-4bd8-9004-073eccf5289a"/>
+          <child xsi:type="archimate:DiagramObject" id="ed018181-fb3e-4d85-bb03-eb523a0c9fc2" targetConnections="8851b2c6-0270-4fec-92e1-e0365dcf8878" archimateElement="aae5673b-3220-4959-bd3b-a4351a94194d">
             <bounds x="14" y="40" width="151" height="55"/>
-            <sourceConnection xsi:type="archimate:Connection" id="93505f4e-898e-429c-b600-c0ab5df5bd36" source="e447b35f-75dd-4355-b95e-246d3832dbb4" target="a2ffe343-bff3-44ff-92a2-972d606b53bb" archimateRelationship="caab7f6b-ecb8-4257-85ef-bbff50ef681b"/>
+            <sourceConnection xsi:type="archimate:Connection" id="7ab78d4c-fbd7-45fd-be95-ba07876019fe" source="ed018181-fb3e-4d85-bb03-eb523a0c9fc2" target="6fb1fe98-614c-4b29-93f0-982a8af99e02" archimateRelationship="4d511da2-7df6-4beb-b47c-78b2f788e5f5"/>
           </child>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="c53a4929-3d5f-4c65-8d3c-76915bb53345" targetConnections="32aca83e-e955-4bda-af6f-2502fb79965e 1e46e600-eaf2-45b9-97d8-de238cd262e4 13e78973-c275-4908-b6e0-8577f4402447 45967641-514b-49dc-bd8a-019a9c85992a e13e102d-8a57-4010-98dd-19d83ea73eff" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
-          <bounds x="365" y="352" width="274" height="271"/>
-          <sourceConnection xsi:type="archimate:Connection" id="a934f1ae-c5ee-4eae-b8af-d5ae7900353e" source="c53a4929-3d5f-4c65-8d3c-76915bb53345" target="974717e5-a94c-4c44-b047-18bf0856f163" archimateRelationship="fec9ce18-5dfb-4483-b947-1d4dd4709b45"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="4fa85870-ad58-42aa-8e8f-6bf5136bd79c" fillColor="#fefc78" archimateElement="cfadf0df-e7a6-4465-ba12-5ad6e915a525">
+        <bounds x="144" y="420" width="601" height="709"/>
+        <child xsi:type="archimate:DiagramObject" id="fae2bcaf-526b-4965-8721-40dad1dcfbab" targetConnections="d27225ae-63a5-4aea-9890-8aff48fe4c73" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75" type="1">
+          <bounds x="24" y="48" width="274" height="93"/>
+          <sourceConnection xsi:type="archimate:Connection" id="1ae0c648-04f3-4816-9273-cf429016c99a" source="fae2bcaf-526b-4965-8721-40dad1dcfbab" target="e3363b17-2ef8-40db-81e1-e99fd17b1e1a" archimateRelationship="8d84949c-da2f-456f-9c85-eb903765cea5"/>
+          <child xsi:type="archimate:DiagramObject" id="e3363b17-2ef8-40db-81e1-e99fd17b1e1a" targetConnections="1ae0c648-04f3-4816-9273-cf429016c99a" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" type="1">
+            <bounds x="48" y="26" width="177" height="52"/>
+          </child>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="017449d2-3f69-41e7-9c9a-71c9c820f770" targetConnections="c1493389-4854-47b4-abef-18c2930c676b" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
-          <bounds x="64" y="567" width="194" height="103"/>
-          <sourceConnection xsi:type="archimate:Connection" id="b9e2f903-e8af-4975-aaea-16e3f3aa2362" source="017449d2-3f69-41e7-9c9a-71c9c820f770" target="06cdffcb-f7d2-4bb6-8ba4-2cdf4119f6dd" archimateRelationship="dd6d220f-2e28-4568-9b32-05078dd07d50"/>
-          <sourceConnection xsi:type="archimate:Connection" id="40669824-7b73-415b-9e95-a6cdbfd890c1" source="017449d2-3f69-41e7-9c9a-71c9c820f770" target="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" archimateRelationship="3de150e4-3c9e-45ad-9c44-fc2dccf967a3">
-            <bendpoint startX="-136" startY="-21" endX="236" endY="160"/>
-            <bendpoint startX="-136" startY="-189" endX="236" endY="-8"/>
-          </sourceConnection>
-          <sourceConnection xsi:type="archimate:Connection" id="32aca83e-e955-4bda-af6f-2502fb79965e" source="017449d2-3f69-41e7-9c9a-71c9c820f770" target="c53a4929-3d5f-4c65-8d3c-76915bb53345" archimateRelationship="ce7896f2-7830-4829-bc08-5d822b5ac10b"/>
-          <sourceConnection xsi:type="archimate:Connection" id="fe43bbe9-a73f-4828-afd7-f8e02bc9a8dc" source="017449d2-3f69-41e7-9c9a-71c9c820f770" target="06ca3175-d7e7-442d-a246-1d91e1342f74" archimateRelationship="0bef2725-e92f-4ade-887e-3bd76eab034c"/>
-          <sourceConnection xsi:type="archimate:Connection" id="b9913af7-14e0-4f3c-9add-168d2b04719e" source="017449d2-3f69-41e7-9c9a-71c9c820f770" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="1a65f425-6273-4339-badf-15bc2122b7fa">
-            <bendpoint startX="-629" startY="14" endX="511" endY="-136"/>
-            <bendpoint startX="-629" startY="86" endX="511" endY="-76"/>
-          </sourceConnection>
-          <child xsi:type="archimate:DiagramObject" id="06cdffcb-f7d2-4bb6-8ba4-2cdf4119f6dd" targetConnections="b9e2f903-e8af-4975-aaea-16e3f3aa2362" archimateElement="1a8879f8-06ce-4925-93ab-ff2222e347aa">
+        <child xsi:type="archimate:DiagramObject" id="f498b412-655e-4c37-ad15-42033b38daf8" targetConnections="16b714b1-6862-4474-908c-7a82ba113637 933947bc-bdf9-4010-8acd-646fb9319a52 0330e8be-8d7b-47af-8ba1-b2d7a58bbdd8 62e1df1f-d2cb-4c8b-8bf6-44ca0563daea 71f88d3b-33a9-4609-a0ec-bba1ac67f001 59983e19-8b8b-4514-99c0-39374e9757c2" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
+          <bounds x="24" y="192" width="274" height="272"/>
+          <sourceConnection xsi:type="archimate:Connection" id="d27225ae-63a5-4aea-9890-8aff48fe4c73" source="f498b412-655e-4c37-ad15-42033b38daf8" target="fae2bcaf-526b-4965-8721-40dad1dcfbab" archimateRelationship="65eeae27-537c-48c0-9390-455f475c2800"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="a0e0ec31-e5e1-4c24-bf29-91efca310a31" targetConnections="75bd1845-7e52-4000-ab12-8bfd77b7777c" archimateElement="a46b13f6-899f-4651-bccd-67685ea0ab9d">
+          <bounds x="384" y="300" width="194" height="103"/>
+          <sourceConnection xsi:type="archimate:Connection" id="9d5b92bc-80d5-4870-901c-566126122564" source="a0e0ec31-e5e1-4c24-bf29-91efca310a31" target="877472ed-d495-437a-b602-e25224f9b3bf" archimateRelationship="32f934ac-0d3b-43d1-9f47-447f6e564ba7"/>
+          <sourceConnection xsi:type="archimate:Connection" id="0330e8be-8d7b-47af-8ba1-b2d7a58bbdd8" source="a0e0ec31-e5e1-4c24-bf29-91efca310a31" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="00c4a55a-5ec6-42e1-91fc-de97c090c9ec"/>
+          <sourceConnection xsi:type="archimate:Connection" id="e8288ba6-ec86-465a-bf3a-873f7cbd240e" source="a0e0ec31-e5e1-4c24-bf29-91efca310a31" target="16c3c5ce-d247-46a8-a08e-ddd1f43d3273" archimateRelationship="6652b746-6c44-479c-b3e9-5f901199d7ef"/>
+          <child xsi:type="archimate:DiagramObject" id="16c3c5ce-d247-46a8-a08e-ddd1f43d3273" targetConnections="e8288ba6-ec86-465a-bf3a-873f7cbd240e" archimateElement="8efc3e85-150e-4e1d-91f5-8989b1c5b89f">
             <bounds x="21" y="41" width="133" height="55"/>
           </child>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="9e568b0c-83ca-4320-8b73-8fae31ae1579" targetConnections="9f95743b-095c-4d29-9c20-817114e9c4dc" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
-          <bounds x="64" y="835" width="194" height="105"/>
-          <sourceConnection xsi:type="archimate:Connection" id="e0e9d126-1d8b-4ba7-858a-58c78c1ee21d" source="9e568b0c-83ca-4320-8b73-8fae31ae1579" target="e888f54a-cfff-45ed-a540-681d0ed30999" archimateRelationship="67b2f7a1-c01c-464b-8caa-b4a9744f35ae"/>
-          <sourceConnection xsi:type="archimate:Connection" id="1e46e600-eaf2-45b9-97d8-de238cd262e4" source="9e568b0c-83ca-4320-8b73-8fae31ae1579" target="c53a4929-3d5f-4c65-8d3c-76915bb53345" archimateRelationship="59d8bd29-7642-49a0-9c2f-48b13fa3fdfc">
-            <bendpoint startX="338" startY="1" endX="-2" endY="356"/>
+        <child xsi:type="archimate:DiagramObject" id="877472ed-d495-437a-b602-e25224f9b3bf" targetConnections="9d5b92bc-80d5-4870-901c-566126122564" archimateElement="2cc22b82-8760-46b4-80cb-118fb3cb04ee" type="1">
+          <bounds x="384" y="216" width="194" height="43"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="7384ecdc-898d-48e2-84ed-4b303afadc66" targetConnections="072b9fc6-d24e-4e7b-8533-485198c0676b" archimateElement="b7b2aa18-f4d7-4341-945c-03837cb989a6" type="1">
+          <bounds x="384" y="492" width="194" height="55"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="9883dd1f-9ae4-4114-af13-96070c6ef9ce" targetConnections="86bc57a8-9cd5-49e7-a58b-9503f4a146dd" archimateElement="c2bcebbc-2082-490d-aa5f-8606e59e3833">
+          <bounds x="384" y="576" width="194" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="072b9fc6-d24e-4e7b-8533-485198c0676b" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="7384ecdc-898d-48e2-84ed-4b303afadc66" archimateRelationship="d965cc0d-8876-416d-a61a-e12259efd4f9"/>
+          <sourceConnection xsi:type="archimate:Connection" id="ccf0be43-8b2f-4a66-895a-1140a7bf184a" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="5407a601-011e-4ad6-96ef-9aaec202badb" archimateRelationship="c63e1909-e2fe-4516-b642-d6749c9ad79c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="933947bc-bdf9-4010-8acd-646fb9319a52" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="254d9661-8126-4963-8d40-e57116fa4186">
+            <bendpoint startX="-336" startY="8" endX="-4" endY="296"/>
           </sourceConnection>
-          <sourceConnection xsi:type="archimate:Connection" id="d909a766-ea2e-426e-aa51-387c568d6bc5" source="9e568b0c-83ca-4320-8b73-8fae31ae1579" target="962c11fb-babf-4546-9114-34d9b978b0d7" archimateRelationship="bf3a3e9b-d6d1-4989-8ef7-021d1f136913"/>
-          <sourceConnection xsi:type="archimate:Connection" id="10b5017b-3e5c-41f5-a011-8b51436343b4" source="9e568b0c-83ca-4320-8b73-8fae31ae1579" target="9883dd1f-9ae4-4114-af13-96070c6ef9ce" archimateRelationship="0e0d90ea-f06a-414b-9eab-4e425f96d110"/>
-          <child xsi:type="archimate:DiagramObject" id="e888f54a-cfff-45ed-a540-681d0ed30999" targetConnections="e0e9d126-1d8b-4ba7-858a-58c78c1ee21d" archimateElement="51eacaa9-ed7b-4307-915c-05a114b2a19d">
+          <sourceConnection xsi:type="archimate:Connection" id="9aeb1419-c9e3-4dcd-9e19-3b8070b68bdd" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="7222c867-1c93-4a93-892d-16fb63fc24dc" archimateRelationship="bce71955-7d5f-4f3d-a47c-a5b0b5af71d8"/>
+          <child xsi:type="archimate:DiagramObject" id="5407a601-011e-4ad6-96ef-9aaec202badb" targetConnections="ccf0be43-8b2f-4a66-895a-1140a7bf184a" archimateElement="cc875beb-f4ff-4952-9600-5eae35fb0d10">
             <bounds x="21" y="41" width="141" height="55"/>
           </child>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="06ca3175-d7e7-442d-a246-1d91e1342f74" targetConnections="fe43bbe9-a73f-4828-afd7-f8e02bc9a8dc" archimateElement="9dc22627-f969-46c8-ac76-9f1ac9b35767" type="1">
-          <bounds x="64" y="496" width="194" height="43"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="2058c6a9-46c5-4f45-8056-bbef625adb4d" fillColor="#fefc78" archimateElement="77d30d3e-5889-4267-ac13-43ae42eec1d1">
+        <bounds x="1488" y="36" width="309" height="1092"/>
+        <child xsi:type="archimate:DiagramObject" id="ad769ad0-1048-436a-8eaa-4d80501333b5" targetConnections="8b6476a9-9ac5-4b21-b51e-cfca7436826f 223ebc06-26bf-4f66-ab2a-7f0b421031e4 5f28e919-c87c-47f3-8be1-15edb751cf19 98c56429-2328-4493-93ad-6ae8f6c17b92" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
+          <bounds x="36" y="468" width="242" height="271"/>
+          <sourceConnection xsi:type="archimate:Connection" id="4483d09a-42f0-4bfd-baac-9e009ade3e20" source="ad769ad0-1048-436a-8eaa-4d80501333b5" target="9e36a53c-74aa-493f-b97e-761e7c2e0457" archimateRelationship="fec9ce18-5dfb-4483-b947-1d4dd4709b45"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="974717e5-a94c-4c44-b047-18bf0856f163" targetConnections="a934f1ae-c5ee-4eae-b8af-d5ae7900353e" archimateElement="0984a188-6642-400c-a42f-20277624eee9" type="1">
-          <bounds x="365" y="223" width="274" height="93"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="962c11fb-babf-4546-9114-34d9b978b0d7" targetConnections="d909a766-ea2e-426e-aa51-387c568d6bc5" archimateElement="7c846708-edd4-4a3a-afad-a711b21abeb4" type="1">
-          <bounds x="64" y="756" width="194" height="55"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="a2ffe343-bff3-44ff-92a2-972d606b53bb" targetConnections="93505f4e-898e-429c-b600-c0ab5df5bd36" archimateElement="197d58a5-2131-41e0-8ec3-37bc46ed9b3d" type="1">
-          <bounds x="365" y="57" width="129" height="68"/>
+        <child xsi:type="archimate:DiagramObject" id="9e36a53c-74aa-493f-b97e-761e7c2e0457" targetConnections="4483d09a-42f0-4bfd-baac-9e009ade3e20" archimateElement="0984a188-6642-400c-a42f-20277624eee9" type="1">
+          <bounds x="35" y="324" width="242" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="d38cfd87-6ba7-4875-9fee-eebb6f223931" source="9e36a53c-74aa-493f-b97e-761e7c2e0457" target="a96f043b-f320-40b1-80ae-918ccf7c2857" archimateRelationship="590cb032-5e90-43cf-a05e-46eaa0beefcc"/>
+          <child xsi:type="archimate:DiagramObject" id="a96f043b-f320-40b1-80ae-918ccf7c2857" targetConnections="d38cfd87-6ba7-4875-9fee-eebb6f223931" archimateElement="b39dc60a-f0ea-48a2-afe5-35c284ad66ed" type="1">
+            <bounds x="24" y="36" width="189" height="52"/>
+          </child>
         </child>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="821c11b1-c2ad-487c-ae4a-4d03d29ab177" archimateElement="efbf9f7a-7b30-462f-a471-3cc2049014b5">
-        <bounds x="770" y="16" width="362" height="978"/>
-        <sourceConnection xsi:type="archimate:Connection" id="56e175f3-5f7f-468c-9b9c-f42b850cc563" source="821c11b1-c2ad-487c-ae4a-4d03d29ab177" target="c6a22f36-1bf8-4972-8697-717a8a664c26" archimateRelationship="f28c0a1d-12f1-4f22-9add-268879bc8a51"/>
-        <sourceConnection xsi:type="archimate:Connection" id="356a0c10-23e5-4bf5-a8a7-21d57bb6f656" source="821c11b1-c2ad-487c-ae4a-4d03d29ab177" target="bdff6701-4961-4bfa-8a3f-049a600308e1" archimateRelationship="b42e098e-f8e9-48a6-9786-1de691e9e707"/>
-        <sourceConnection xsi:type="archimate:Connection" id="21991226-5cda-4fd4-966a-cbab851e8f67" source="821c11b1-c2ad-487c-ae4a-4d03d29ab177" target="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" archimateRelationship="8061137c-057b-42fe-b50e-08493914d415"/>
-        <child xsi:type="archimate:DiagramObject" id="c6a22f36-1bf8-4972-8697-717a8a664c26" targetConnections="56e175f3-5f7f-468c-9b9c-f42b850cc563 0c3dfdf5-c4d9-45c2-bb4f-aab6da2a518e" archimateElement="8532f211-fbcb-4255-a32d-91871c7336be">
-          <bounds x="72" y="768" width="205" height="78"/>
-          <sourceConnection xsi:type="archimate:Connection" id="13e78973-c275-4908-b6e0-8577f4402447" source="c6a22f36-1bf8-4972-8697-717a8a664c26" target="c53a4929-3d5f-4c65-8d3c-76915bb53345" archimateRelationship="604120c2-2acc-4b05-a43d-c707a73ad5dc">
-            <bendpoint startX="657" endX="-80" endY="239"/>
-          </sourceConnection>
-          <sourceConnection xsi:type="archimate:Connection" id="004656db-2e6c-449a-962a-b07f2ce4d7a1" source="c6a22f36-1bf8-4972-8697-717a8a664c26" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="b8077982-bc5b-42e6-baad-9a371e82443c">
-            <bendpoint startX="-260" startY="5" endX="511" endY="44"/>
-            <bendpoint startX="-260" startY="-91" endX="511" endY="-64"/>
-          </sourceConnection>
+      <child xsi:type="archimate:DiagramObject" id="82992a28-4422-46ff-af09-f6d57f01d73e" fillColor="#fefc78" archimateElement="ead927f6-aada-4517-9de7-5dcb477a7e36">
+        <bounds x="1140" y="36" width="309" height="1092"/>
+        <child xsi:type="archimate:DiagramObject" id="27534513-13f5-45f7-856d-19b73aea4ba9" targetConnections="f2438022-67e9-40a0-b820-a104ac3b4945" archimateElement="197d58a5-2131-41e0-8ec3-37bc46ed9b3d" type="1">
+          <bounds x="59" y="63" width="193" height="44"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="bdff6701-4961-4bfa-8a3f-049a600308e1" targetConnections="356a0c10-23e5-4bf5-a8a7-21d57bb6f656" archimateElement="98f08e2a-55bb-4cf3-88f8-a72c328068e1">
-          <bounds x="72" y="646" width="205" height="100"/>
-          <sourceConnection xsi:type="archimate:Connection" id="0bbc3951-2c9e-474a-9f1f-baa953a73b6b" source="bdff6701-4961-4bfa-8a3f-049a600308e1" target="54d80283-d74f-4492-891b-fdb99567b655" archimateRelationship="f4d55798-6548-4f2b-8a36-dfb103680504"/>
-          <sourceConnection xsi:type="archimate:Connection" id="0c3dfdf5-c4d9-45c2-bb4f-aab6da2a518e" source="bdff6701-4961-4bfa-8a3f-049a600308e1" target="c6a22f36-1bf8-4972-8697-717a8a664c26" archimateRelationship="4ccd9580-1076-4ab8-9e7c-51b10d00aa48"/>
-          <sourceConnection xsi:type="archimate:Connection" id="c1493389-4854-47b4-abef-18c2930c676b" source="bdff6701-4961-4bfa-8a3f-049a600308e1" target="017449d2-3f69-41e7-9c9a-71c9c820f770" archimateRelationship="b1837450-f7fb-4eb5-8d35-95206ec0ad1c"/>
-          <sourceConnection xsi:type="archimate:Connection" id="6fd8ec93-60ef-4162-8a8d-a6d74d29fab0" source="bdff6701-4961-4bfa-8a3f-049a600308e1" target="a0e0ec31-e5e1-4c24-bf29-91efca310a31" archimateRelationship="dbe8aa22-0fa9-4cf4-9585-78e68a698731"/>
-          <child xsi:type="archimate:DiagramObject" id="54d80283-d74f-4492-891b-fdb99567b655" targetConnections="0bbc3951-2c9e-474a-9f1f-baa953a73b6b" archimateElement="e573296a-1aac-4c71-871c-1baf2417c996">
-            <bounds x="17" y="45" width="152" height="47"/>
+        <child xsi:type="archimate:DiagramObject" id="fe5a244d-768b-4282-86aa-de7d27a6ba52" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
+          <bounds x="59" y="144" width="193" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="689f5200-42e9-48d5-87db-87c6ad1e58f7" source="fe5a244d-768b-4282-86aa-de7d27a6ba52" target="8e0270bb-b131-4ec9-a61d-038a4e8eac3e" archimateRelationship="b85300bf-77ed-49c7-84a8-011be915cee2"/>
+          <sourceConnection xsi:type="archimate:Connection" id="19e21e5e-9972-4031-a758-39e24676d9e0" source="fe5a244d-768b-4282-86aa-de7d27a6ba52" target="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" archimateRelationship="885e9e6f-9da6-4924-8aaf-d8c5ab20552b"/>
+          <child xsi:type="archimate:DiagramObject" id="8e0270bb-b131-4ec9-a61d-038a4e8eac3e" targetConnections="689f5200-42e9-48d5-87db-87c6ad1e58f7" archimateElement="68e59636-1f53-4336-9cfd-64fa6acae825">
+            <bounds x="14" y="40" width="151" height="55"/>
+            <sourceConnection xsi:type="archimate:Connection" id="f2438022-67e9-40a0-b820-a104ac3b4945" source="8e0270bb-b131-4ec9-a61d-038a4e8eac3e" target="27534513-13f5-45f7-856d-19b73aea4ba9" archimateRelationship="caab7f6b-ecb8-4257-85ef-bbff50ef681b"/>
           </child>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" targetConnections="40669824-7b73-415b-9e95-a6cdbfd890c1 21991226-5cda-4fd4-966a-cbab851e8f67" archimateElement="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe">
-          <bounds x="68" y="381" width="205" height="113"/>
-          <sourceConnection xsi:type="archimate:Connection" id="11e835eb-cd70-442e-9075-64b761ba2810" source="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" target="c31d96fc-1456-400e-9774-11609233c08d" archimateRelationship="3ca5b18c-b380-4be6-95f6-d6301b907ef5"/>
-          <sourceConnection xsi:type="archimate:Connection" id="ee4d70d9-aeaf-4f06-8665-f928797f7315" source="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" target="c8a0c289-e835-4b5a-a167-847da6636783" archimateRelationship="8d9b2549-3ec1-40a7-a2bf-709d6c667325"/>
-          <sourceConnection xsi:type="archimate:Connection" id="9c649f5f-3276-4fe1-be66-cdfc3b04243c" source="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="6188230a-d639-46ea-9351-4bd0e798f98e">
-            <bendpoint startX="-496" startY="-9" endX="271" endY="-352"/>
+        <child xsi:type="archimate:DiagramObject" id="bf276296-4164-41a0-9319-fc76d321c28c" targetConnections="4a0d9d93-c966-4d3d-af07-87a3b137bdb6" archimateElement="9dc22627-f969-46c8-ac76-9f1ac9b35767" type="1">
+          <bounds x="60" y="600" width="194" height="43"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="aedc56e0-6a11-44ad-8dc6-e9eef3df26b3" targetConnections="0c6fcfbe-d10e-430f-863a-26bfd73508a6" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
+          <bounds x="59" y="682" width="194" height="103"/>
+          <sourceConnection xsi:type="archimate:Connection" id="8b6476a9-9ac5-4b21-b51e-cfca7436826f" source="aedc56e0-6a11-44ad-8dc6-e9eef3df26b3" target="ad769ad0-1048-436a-8eaa-4d80501333b5" archimateRelationship="ce7896f2-7830-4829-bc08-5d822b5ac10b"/>
+          <sourceConnection xsi:type="archimate:Connection" id="4a0d9d93-c966-4d3d-af07-87a3b137bdb6" source="aedc56e0-6a11-44ad-8dc6-e9eef3df26b3" target="bf276296-4164-41a0-9319-fc76d321c28c" archimateRelationship="0bef2725-e92f-4ade-887e-3bd76eab034c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="c5752e3b-3975-4642-bdbb-c43d2b6315ee" source="aedc56e0-6a11-44ad-8dc6-e9eef3df26b3" target="9f66db0a-5dc6-44fe-97ef-3668e6b78faa" archimateRelationship="dd6d220f-2e28-4568-9b32-05078dd07d50"/>
+          <sourceConnection xsi:type="archimate:Connection" id="c8053d09-ad88-4ad2-9ac1-21a0c13e5474" source="aedc56e0-6a11-44ad-8dc6-e9eef3df26b3" target="eba2559d-6997-4cb8-ba54-14a4f77856a4" archimateRelationship="3de150e4-3c9e-45ad-9c44-fc2dccf967a3">
+            <bendpoint startX="-132" startY="-13" endX="210" endY="147"/>
+            <bendpoint startX="-132" startY="-169" endX="210" endY="-9"/>
           </sourceConnection>
-          <child xsi:type="archimate:DiagramObject" id="c31d96fc-1456-400e-9774-11609233c08d" targetConnections="11e835eb-cd70-442e-9075-64b761ba2810" archimateElement="10cb9a93-25d4-4da1-8964-c183b3ff910c">
-            <bounds x="20" y="47" width="152" height="55"/>
+          <child xsi:type="archimate:DiagramObject" id="9f66db0a-5dc6-44fe-97ef-3668e6b78faa" targetConnections="c5752e3b-3975-4642-bdbb-c43d2b6315ee" archimateElement="1a8879f8-06ce-4925-93ab-ff2222e347aa">
+            <bounds x="21" y="41" width="133" height="55"/>
           </child>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="3e7f4be1-e92f-4770-aa58-a896d5bd7b33" archimateElement="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349">
-          <bounds x="70" y="185" width="204" height="109"/>
-          <sourceConnection xsi:type="archimate:Connection" id="a88fae55-8b2a-4743-9631-26cb66bcceef" source="3e7f4be1-e92f-4770-aa58-a896d5bd7b33" target="c392e5cf-8d0f-4973-80fc-2deb9dea3dc6" archimateRelationship="3dfc3dbf-5711-45b6-930a-0dc44678676a"/>
-          <sourceConnection xsi:type="archimate:Connection" id="45967641-514b-49dc-bd8a-019a9c85992a" source="3e7f4be1-e92f-4770-aa58-a896d5bd7b33" target="c53a4929-3d5f-4c65-8d3c-76915bb53345" archimateRelationship="9102c6a7-d07f-4de0-94d7-273bb7bca236">
-            <bendpoint startX="409" startY="17" endX="-307" endY="-215"/>
-            <bendpoint startX="410" startY="142" endX="-306" endY="-90"/>
+        <child xsi:type="archimate:DiagramObject" id="8d387d6a-7a87-4650-9262-007d6ab2158c" targetConnections="6948fb54-540b-489a-b94a-c38dfeb8b2ae" archimateElement="7c846708-edd4-4a3a-afad-a711b21abeb4" type="1">
+          <bounds x="60" y="876" width="194" height="55"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="7222c867-1c93-4a93-892d-16fb63fc24dc" targetConnections="9aeb1419-c9e3-4dcd-9e19-3b8070b68bdd" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
+          <bounds x="60" y="955" width="194" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="6948fb54-540b-489a-b94a-c38dfeb8b2ae" source="7222c867-1c93-4a93-892d-16fb63fc24dc" target="8d387d6a-7a87-4650-9262-007d6ab2158c" archimateRelationship="bf3a3e9b-d6d1-4989-8ef7-021d1f136913"/>
+          <sourceConnection xsi:type="archimate:Connection" id="223ebc06-26bf-4f66-ab2a-7f0b421031e4" source="7222c867-1c93-4a93-892d-16fb63fc24dc" target="ad769ad0-1048-436a-8eaa-4d80501333b5" archimateRelationship="59d8bd29-7642-49a0-9c2f-48b13fa3fdfc">
+            <bendpoint startX="375" startY="4" endX="-1" endY="406"/>
           </sourceConnection>
-          <sourceConnection xsi:type="archimate:Connection" id="dc11ca8a-747b-4bd4-965b-374fd332a36e" source="3e7f4be1-e92f-4770-aa58-a896d5bd7b33" target="f70768de-7e83-4eb0-8cbc-3acdc4117185" archimateRelationship="e08143cb-a72b-4f01-b442-a8c905603be7"/>
-          <sourceConnection xsi:type="archimate:Connection" id="bc2ab95f-e755-4f12-8a2f-954670f308c1" source="3e7f4be1-e92f-4770-aa58-a896d5bd7b33" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="5ad8159f-f033-40fd-977d-34f2694d728b">
-            <bendpoint startX="-510" startY="117" endX="259" endY="-424"/>
+          <sourceConnection xsi:type="archimate:Connection" id="fdc89cdb-b45d-49e0-910b-48307b68a12f" source="7222c867-1c93-4a93-892d-16fb63fc24dc" target="ac22adb9-d5c1-43cd-8205-e92507d85626" archimateRelationship="67b2f7a1-c01c-464b-8caa-b4a9744f35ae"/>
+          <sourceConnection xsi:type="archimate:Connection" id="86bc57a8-9cd5-49e7-a58b-9503f4a146dd" source="7222c867-1c93-4a93-892d-16fb63fc24dc" target="9883dd1f-9ae4-4114-af13-96070c6ef9ce" archimateRelationship="0e0d90ea-f06a-414b-9eab-4e425f96d110"/>
+          <child xsi:type="archimate:DiagramObject" id="ac22adb9-d5c1-43cd-8205-e92507d85626" targetConnections="fdc89cdb-b45d-49e0-910b-48307b68a12f" archimateElement="51eacaa9-ed7b-4307-915c-05a114b2a19d">
+            <bounds x="21" y="41" width="141" height="55"/>
+          </child>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="a8f713bd-d89c-4077-a747-ae6490eac2d2" fillColor="#fefc78" archimateElement="0077ac29-da6d-426c-90a0-51e987d5f202">
+        <bounds x="792" y="36" width="309" height="1092"/>
+        <child xsi:type="archimate:DiagramObject" id="335b2da3-467a-4703-923f-296d9a6d297b" archimateElement="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349">
+          <bounds x="62" y="308" width="204" height="109"/>
+          <sourceConnection xsi:type="archimate:Connection" id="6740c13e-a6ba-4848-8a24-15793194d169" source="335b2da3-467a-4703-923f-296d9a6d297b" target="1b10f363-68e2-4610-b6a2-82214a50c9fd" archimateRelationship="e08143cb-a72b-4f01-b442-a8c905603be7"/>
+          <sourceConnection xsi:type="archimate:Connection" id="13f62a45-0430-4fcf-a7d0-fe8495319988" source="335b2da3-467a-4703-923f-296d9a6d297b" target="5b60d33f-3c44-47e2-85d0-dbcd77dd88e2" archimateRelationship="3dfc3dbf-5711-45b6-930a-0dc44678676a"/>
+          <sourceConnection xsi:type="archimate:Connection" id="98c56429-2328-4493-93ad-6ae8f6c17b92" source="335b2da3-467a-4703-923f-296d9a6d297b" target="ad769ad0-1048-436a-8eaa-4d80501333b5" archimateRelationship="9102c6a7-d07f-4de0-94d7-273bb7bca236">
+            <bendpoint startX="160" startY="-2" endX="-528" endY="-230"/>
+            <bendpoint startX="520" startY="154" endX="-168" endY="-74"/>
           </sourceConnection>
-          <child xsi:type="archimate:DiagramObject" id="c392e5cf-8d0f-4973-80fc-2deb9dea3dc6" targetConnections="a88fae55-8b2a-4743-9631-26cb66bcceef" archimateElement="fede8dba-b24e-4347-9487-e9901da917f9">
+          <sourceConnection xsi:type="archimate:Connection" id="71f88d3b-33a9-4609-a0ec-bba1ac67f001" source="335b2da3-467a-4703-923f-296d9a6d297b" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="91467111-4dc4-4b4d-9138-4328809f18b3">
+            <bendpoint startX="-200" startY="-2" endX="451" endY="-352"/>
+          </sourceConnection>
+          <child xsi:type="archimate:DiagramObject" id="5b60d33f-3c44-47e2-85d0-dbcd77dd88e2" targetConnections="13f62a45-0430-4fcf-a7d0-fe8495319988" archimateElement="fede8dba-b24e-4347-9487-e9901da917f9">
             <bounds x="22" y="52" width="148" height="47"/>
           </child>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="c8a0c289-e835-4b5a-a167-847da6636783" targetConnections="ee4d70d9-aeaf-4f06-8665-f928797f7315" archimateElement="83a086f5-68c0-475d-88e8-c53fc033a533" type="1">
-          <bounds x="69" y="307" width="205" height="43"/>
+        <child xsi:type="archimate:DiagramObject" id="1b10f363-68e2-4610-b6a2-82214a50c9fd" targetConnections="6740c13e-a6ba-4848-8a24-15793194d169" archimateElement="5647d2da-812c-4a0f-af6e-bac94daa4aeb" type="1">
+          <bounds x="60" y="216" width="204" height="55"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="f70768de-7e83-4eb0-8cbc-3acdc4117185" targetConnections="dc11ca8a-747b-4bd4-965b-374fd332a36e" archimateElement="5647d2da-812c-4a0f-af6e-bac94daa4aeb" type="1">
-          <bounds x="68" y="93" width="204" height="55"/>
+        <child xsi:type="archimate:DiagramObject" id="f22c2356-82c6-46d2-afc0-d782939ecf3c" targetConnections="d77bb573-00ee-4cb3-a10a-d8bf1f3d643d f9545755-d231-4721-b8ef-e1a3ce7079c4" archimateElement="8532f211-fbcb-4255-a32d-91871c7336be">
+          <bounds x="60" y="924" width="205" height="60"/>
+          <sourceConnection xsi:type="archimate:Connection" id="5f28e919-c87c-47f3-8be1-15edb751cf19" source="f22c2356-82c6-46d2-afc0-d782939ecf3c" target="ad769ad0-1048-436a-8eaa-4d80501333b5" archimateRelationship="604120c2-2acc-4b05-a43d-c707a73ad5dc">
+            <bendpoint startX="162" startY="6" endX="-529" endY="357"/>
+            <bendpoint startX="162" startY="-138" endX="-529" endY="213"/>
+            <bendpoint startX="630" startY="-138" endX="-61" endY="213"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="62e1df1f-d2cb-4c8b-8bf6-44ca0563daea" source="f22c2356-82c6-46d2-afc0-d782939ecf3c" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="b8077982-bc5b-42e6-baad-9a371e82443c">
+            <bendpoint startX="-186" startY="6" endX="464" endY="248"/>
+            <bendpoint startX="-186" startY="-138" endX="464" endY="104"/>
+          </sourceConnection>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="67ebc6c0-d232-4598-beb4-3db16a43ccd0" targetConnections="64d8dcb0-9bf5-4381-87f1-6193273a051e" archimateElement="98f08e2a-55bb-4cf3-88f8-a72c328068e1">
+          <bounds x="60" y="720" width="205" height="100"/>
+          <sourceConnection xsi:type="archimate:Connection" id="964c45a1-530b-4e1f-b1c0-7aa801f3eaf5" source="67ebc6c0-d232-4598-beb4-3db16a43ccd0" target="9285e0b2-81b4-4128-9be5-709fef126c32" archimateRelationship="f4d55798-6548-4f2b-8a36-dfb103680504"/>
+          <sourceConnection xsi:type="archimate:Connection" id="d77bb573-00ee-4cb3-a10a-d8bf1f3d643d" source="67ebc6c0-d232-4598-beb4-3db16a43ccd0" target="f22c2356-82c6-46d2-afc0-d782939ecf3c" archimateRelationship="4ccd9580-1076-4ab8-9e7c-51b10d00aa48">
+            <bendpoint startX="-78" startY="106" endX="-78" endY="-78"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="0c6fcfbe-d10e-430f-863a-26bfd73508a6" source="67ebc6c0-d232-4598-beb4-3db16a43ccd0" target="aedc56e0-6a11-44ad-8dc6-e9eef3df26b3" archimateRelationship="b1837450-f7fb-4eb5-8d35-95206ec0ad1c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="75bd1845-7e52-4000-ab12-8bfd77b7777c" source="67ebc6c0-d232-4598-beb4-3db16a43ccd0" target="a0e0ec31-e5e1-4c24-bf29-91efca310a31" archimateRelationship="dbe8aa22-0fa9-4cf4-9585-78e68a698731"/>
+          <child xsi:type="archimate:DiagramObject" id="9285e0b2-81b4-4128-9be5-709fef126c32" targetConnections="964c45a1-530b-4e1f-b1c0-7aa801f3eaf5" archimateElement="e573296a-1aac-4c71-871c-1baf2417c996">
+            <bounds x="17" y="45" width="152" height="47"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="96c06781-75ee-4c0d-8e58-6c300d7cb117" archimateElement="16e6b406-99cd-4255-a1cc-6d6a8eb25fad">
+          <bounds x="108" y="852" width="72" height="40"/>
+          <sourceConnection xsi:type="archimate:Connection" id="45e4f02b-ae41-48ae-b0aa-e3ff0c11cb52" source="96c06781-75ee-4c0d-8e58-6c300d7cb117" target="1889451d-6885-490f-b3f6-2dd5b83205eb" archimateRelationship="a519c4a0-7f3d-4469-bb60-7d1404fa8ef0"/>
+          <sourceConnection xsi:type="archimate:Connection" id="64d8dcb0-9bf5-4381-87f1-6193273a051e" source="96c06781-75ee-4c0d-8e58-6c300d7cb117" target="67ebc6c0-d232-4598-beb4-3db16a43ccd0" archimateRelationship="96ac082a-4934-4e40-836a-8ad4ef304e95"/>
+          <sourceConnection xsi:type="archimate:Connection" id="f9545755-d231-4721-b8ef-e1a3ce7079c4" source="96c06781-75ee-4c0d-8e58-6c300d7cb117" target="f22c2356-82c6-46d2-afc0-d782939ecf3c" archimateRelationship="f6b64b03-3d7d-4252-b62f-8eda3a01958a"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="1889451d-6885-490f-b3f6-2dd5b83205eb" targetConnections="45e4f02b-ae41-48ae-b0aa-e3ff0c11cb52" archimateElement="40e6d34e-02c4-4b57-8af3-a3bfc8c89962" type="1">
+          <bounds x="216" y="852" width="84" height="40"/>
         </child>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="f498b412-655e-4c37-ad15-42033b38daf8" targetConnections="16b714b1-6862-4474-908c-7a82ba113637 933947bc-bdf9-4010-8acd-646fb9319a52 0330e8be-8d7b-47af-8ba1-b2d7a58bbdd8 bc2ab95f-e755-4f12-8a2f-954670f308c1 9c649f5f-3276-4fe1-be66-cdfc3b04243c 004656db-2e6c-449a-962a-b07f2ce4d7a1 b9913af7-14e0-4f3c-9add-168d2b04719e" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
-        <bounds x="36" y="660" width="274" height="272"/>
-        <sourceConnection xsi:type="archimate:Connection" id="d27225ae-63a5-4aea-9890-8aff48fe4c73" source="f498b412-655e-4c37-ad15-42033b38daf8" target="fae2bcaf-526b-4965-8721-40dad1dcfbab" archimateRelationship="65eeae27-537c-48c0-9390-455f475c2800"/>
+      <child xsi:type="archimate:DiagramObject" id="4ed6aa5e-2007-41ab-b719-874aada12ee5" targetConnections="e1f3b7ea-eaca-4ae4-8f45-d4af08847ab9" archimateElement="83a086f5-68c0-475d-88e8-c53fc033a533" type="1">
+        <bounds x="853" y="479" width="205" height="43"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="877472ed-d495-437a-b602-e25224f9b3bf" targetConnections="9d5b92bc-80d5-4870-901c-566126122564" archimateElement="2cc22b82-8760-46b4-80cb-118fb3cb04ee" type="1">
-        <bounds x="408" y="516" width="194" height="43"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="a0e0ec31-e5e1-4c24-bf29-91efca310a31" targetConnections="6fd8ec93-60ef-4162-8a8d-a6d74d29fab0" archimateElement="a46b13f6-899f-4651-bccd-67685ea0ab9d">
-        <bounds x="408" y="600" width="194" height="103"/>
-        <sourceConnection xsi:type="archimate:Connection" id="9d5b92bc-80d5-4870-901c-566126122564" source="a0e0ec31-e5e1-4c24-bf29-91efca310a31" target="877472ed-d495-437a-b602-e25224f9b3bf" archimateRelationship="32f934ac-0d3b-43d1-9f47-447f6e564ba7"/>
-        <sourceConnection xsi:type="archimate:Connection" id="0330e8be-8d7b-47af-8ba1-b2d7a58bbdd8" source="a0e0ec31-e5e1-4c24-bf29-91efca310a31" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="00c4a55a-5ec6-42e1-91fc-de97c090c9ec"/>
-        <sourceConnection xsi:type="archimate:Connection" id="e8288ba6-ec86-465a-bf3a-873f7cbd240e" source="a0e0ec31-e5e1-4c24-bf29-91efca310a31" target="16c3c5ce-d247-46a8-a08e-ddd1f43d3273" archimateRelationship="6652b746-6c44-479c-b3e9-5f901199d7ef"/>
-        <sourceConnection xsi:type="archimate:Connection" id="e13e102d-8a57-4010-98dd-19d83ea73eff" source="a0e0ec31-e5e1-4c24-bf29-91efca310a31" target="c53a4929-3d5f-4c65-8d3c-76915bb53345" archimateRelationship="424515ef-9f7d-470b-a218-c9f833280361">
-          <bendpoint startX="502" startY="-39" endX="-574" endY="97"/>
-          <bendpoint startX="502" startY="-159" endX="-574" endY="-23"/>
+      <child xsi:type="archimate:DiagramObject" id="eba2559d-6997-4cb8-ba54-14a4f77856a4" targetConnections="c8053d09-ad88-4ad2-9ac1-21a0c13e5474" archimateElement="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe">
+        <bounds x="852" y="553" width="205" height="113"/>
+        <sourceConnection xsi:type="archimate:Connection" id="6e274078-896c-440a-9197-f7be55d93b84" source="eba2559d-6997-4cb8-ba54-14a4f77856a4" target="c196a8c3-1377-4cdd-9f97-ef8f1633bd05" archimateRelationship="3ca5b18c-b380-4be6-95f6-d6301b907ef5"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e1f3b7ea-eaca-4ae4-8f45-d4af08847ab9" source="eba2559d-6997-4cb8-ba54-14a4f77856a4" target="4ed6aa5e-2007-41ab-b719-874aada12ee5" archimateRelationship="8d9b2549-3ec1-40a7-a2bf-709d6c667325"/>
+        <sourceConnection xsi:type="archimate:Connection" id="59983e19-8b8b-4514-99c0-39374e9757c2" source="eba2559d-6997-4cb8-ba54-14a4f77856a4" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="6188230a-d639-46ea-9351-4bd0e798f98e">
+          <bendpoint startX="-185" startY="16" endX="464" endY="-124"/>
         </sourceConnection>
-        <child xsi:type="archimate:DiagramObject" id="16c3c5ce-d247-46a8-a08e-ddd1f43d3273" targetConnections="e8288ba6-ec86-465a-bf3a-873f7cbd240e" archimateElement="8efc3e85-150e-4e1d-91f5-8989b1c5b89f">
-          <bounds x="21" y="41" width="133" height="55"/>
+        <child xsi:type="archimate:DiagramObject" id="c196a8c3-1377-4cdd-9f97-ef8f1633bd05" targetConnections="6e274078-896c-440a-9197-f7be55d93b84" archimateElement="10cb9a93-25d4-4da1-8964-c183b3ff910c">
+          <bounds x="20" y="47" width="152" height="55"/>
         </child>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="7384ecdc-898d-48e2-84ed-4b303afadc66" targetConnections="072b9fc6-d24e-4e7b-8533-485198c0676b" archimateElement="b7b2aa18-f4d7-4341-945c-03837cb989a6" type="1">
-        <bounds x="408" y="744" width="194" height="55"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="9883dd1f-9ae4-4114-af13-96070c6ef9ce" targetConnections="10b5017b-3e5c-41f5-a011-8b51436343b4" archimateElement="c2bcebbc-2082-490d-aa5f-8606e59e3833">
-        <bounds x="408" y="828" width="194" height="105"/>
-        <sourceConnection xsi:type="archimate:Connection" id="072b9fc6-d24e-4e7b-8533-485198c0676b" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="7384ecdc-898d-48e2-84ed-4b303afadc66" archimateRelationship="d965cc0d-8876-416d-a61a-e12259efd4f9"/>
-        <sourceConnection xsi:type="archimate:Connection" id="ccf0be43-8b2f-4a66-895a-1140a7bf184a" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="5407a601-011e-4ad6-96ef-9aaec202badb" archimateRelationship="c63e1909-e2fe-4516-b642-d6749c9ad79c"/>
-        <sourceConnection xsi:type="archimate:Connection" id="933947bc-bdf9-4010-8acd-646fb9319a52" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="254d9661-8126-4963-8d40-e57116fa4186"/>
-        <sourceConnection xsi:type="archimate:Connection" id="9f95743b-095c-4d29-9c20-817114e9c4dc" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="9e568b0c-83ca-4320-8b73-8fae31ae1579" archimateRelationship="bce71955-7d5f-4f3d-a47c-a5b0b5af71d8"/>
-        <child xsi:type="archimate:DiagramObject" id="5407a601-011e-4ad6-96ef-9aaec202badb" targetConnections="ccf0be43-8b2f-4a66-895a-1140a7bf184a" archimateElement="cc875beb-f4ff-4952-9600-5eae35fb0d10">
-          <bounds x="21" y="41" width="141" height="55"/>
-        </child>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="fae2bcaf-526b-4965-8721-40dad1dcfbab" targetConnections="d27225ae-63a5-4aea-9890-8aff48fe4c73" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75" type="1">
-        <bounds x="36" y="516" width="274" height="93"/>
-        <sourceConnection xsi:type="archimate:Connection" id="1ae0c648-04f3-4816-9273-cf429016c99a" source="fae2bcaf-526b-4965-8721-40dad1dcfbab" target="e3363b17-2ef8-40db-81e1-e99fd17b1e1a" archimateRelationship="8d84949c-da2f-456f-9c85-eb903765cea5"/>
-        <child xsi:type="archimate:DiagramObject" id="e3363b17-2ef8-40db-81e1-e99fd17b1e1a" targetConnections="1ae0c648-04f3-4816-9273-cf429016c99a" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" type="1">
-          <bounds x="48" y="26" width="177" height="52"/>
-        </child>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="6fb1fe98-614c-4b29-93f0-982a8af99e02" targetConnections="7ab78d4c-fbd7-45fd-be95-ba07876019fe" archimateElement="5e3cba4d-6785-4a6a-80e7-ccabcb45c0e3" type="1">
-        <bounds x="240" y="84" width="129" height="68"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" targetConnections="02add9ad-9baf-44ff-9276-ea22a7ab9a18" archimateElement="538aa797-e00b-442f-af83-9a8e7e85aadd">
-        <bounds x="444" y="60" width="196" height="105"/>
-        <sourceConnection xsi:type="archimate:Connection" id="8851b2c6-0270-4fec-92e1-e0365dcf8878" source="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" target="ed018181-fb3e-4d85-bb03-eb523a0c9fc2" archimateRelationship="49c8dabe-7bb4-4d12-b9c6-1cbd98f0c9a3"/>
-        <sourceConnection xsi:type="archimate:Connection" id="16b714b1-6862-4474-908c-7a82ba113637" source="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="3a2019bf-1f10-4bd8-9004-073eccf5289a"/>
-        <child xsi:type="archimate:DiagramObject" id="ed018181-fb3e-4d85-bb03-eb523a0c9fc2" targetConnections="8851b2c6-0270-4fec-92e1-e0365dcf8878" archimateElement="aae5673b-3220-4959-bd3b-a4351a94194d">
-          <bounds x="14" y="40" width="151" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="7ab78d4c-fbd7-45fd-be95-ba07876019fe" source="ed018181-fb3e-4d85-bb03-eb523a0c9fc2" target="6fb1fe98-614c-4b29-93f0-982a8af99e02" archimateRelationship="4d511da2-7df6-4beb-b47c-78b2f788e5f5"/>
-        </child>
-      </child>
+      <documentation>This diagram shows a variation of how the application components defined in the ISA can be deployed to nodes in the technology architecture. In this variant the Comptetent Authority acting as the Data Consumer operates its own SMP and AP.
+</documentation>
     </element>
     <element xsi:type="archimate:ArchimateDiagramModel" name="DC process (explicit req => consent)" id="70f3574c-42f5-4e27-bd84-c86657b78b97" viewpoint="business_process_cooperation">
       <child xsi:type="archimate:DiagramObject" id="5ebd342f-d0d0-4be9-ad29-3488601f8925" targetConnections="80271483-a477-4d07-a450-1c1004b77060" archimateElement="fad8e664-4fad-4d4a-9a10-74c710c3b97a">
@@ -1283,6 +1376,309 @@ I have made the separation between BDXL back-end and the DNS server explicit in 
         </sourceConnection>
       </child>
       <documentation>Based on the assumption that consent is included when the User confirms the request for getting the evidence the activity to get consent is removed from this process diagram. </documentation>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Deployment topology #3" id="b4573b3d-2042-4047-9e43-bea4ba4d2f0d">
+      <child xsi:type="archimate:DiagramObject" id="a51de784-1ceb-4780-b817-5769c5fedf80" fillColor="#fefc78" archimateElement="b84f65fc-b9ae-4104-bb70-8626630a4db8">
+        <bounds x="144" y="36" width="600" height="348"/>
+        <child xsi:type="archimate:DiagramObject" id="59e4b8e8-41b8-4406-9b3c-b7fb221241bb" targetConnections="7adad497-deea-4cd9-a6f2-60f2dad7486d" archimateElement="5e3cba4d-6785-4a6a-80e7-ccabcb45c0e3" type="1">
+          <bounds x="384" y="60" width="193" height="44"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="da032665-44b4-4f87-a701-d9149325abd9" targetConnections="0c22f1ea-cc97-4ff6-916c-741208b74508" archimateElement="538aa797-e00b-442f-af83-9a8e7e85aadd">
+          <bounds x="384" y="144" width="193" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="574c6141-589b-4617-9059-c84f5f7e4487" source="da032665-44b4-4f87-a701-d9149325abd9" target="0b3ac515-02b8-4347-b043-d2cc460e097b" archimateRelationship="49c8dabe-7bb4-4d12-b9c6-1cbd98f0c9a3"/>
+          <sourceConnection xsi:type="archimate:Connection" id="f6f31065-90de-400b-a2a3-98f55fc47cf1" source="da032665-44b4-4f87-a701-d9149325abd9" target="6c91790e-83a0-4ebb-a284-00efb9a2c9be" archimateRelationship="3a2019bf-1f10-4bd8-9004-073eccf5289a"/>
+          <child xsi:type="archimate:DiagramObject" id="0b3ac515-02b8-4347-b043-d2cc460e097b" targetConnections="574c6141-589b-4617-9059-c84f5f7e4487" archimateElement="aae5673b-3220-4959-bd3b-a4351a94194d">
+            <bounds x="14" y="40" width="151" height="55"/>
+            <sourceConnection xsi:type="archimate:Connection" id="7adad497-deea-4cd9-a6f2-60f2dad7486d" source="0b3ac515-02b8-4347-b043-d2cc460e097b" target="59e4b8e8-41b8-4406-9b3c-b7fb221241bb" archimateRelationship="4d511da2-7df6-4beb-b47c-78b2f788e5f5"/>
+          </child>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="ef6dbd1d-ef97-49d1-b0cd-c16db8c790d3" fillColor="#fefc78" archimateElement="cfadf0df-e7a6-4465-ba12-5ad6e915a525">
+        <bounds x="144" y="420" width="601" height="709"/>
+        <child xsi:type="archimate:DiagramObject" id="7b9df1dc-b0d3-4906-90f7-f8d2da1a27db" targetConnections="a2fd5820-6539-46a0-b3b2-f65d8ac785b8" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75" type="1">
+          <bounds x="24" y="48" width="274" height="93"/>
+          <sourceConnection xsi:type="archimate:Connection" id="20a142ab-a4c9-4930-9e5c-90012c513dc6" source="7b9df1dc-b0d3-4906-90f7-f8d2da1a27db" target="f93c9f7b-caba-41fb-9a30-57efa7bad86b" archimateRelationship="8d84949c-da2f-456f-9c85-eb903765cea5"/>
+          <child xsi:type="archimate:DiagramObject" id="f93c9f7b-caba-41fb-9a30-57efa7bad86b" targetConnections="20a142ab-a4c9-4930-9e5c-90012c513dc6" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" type="1">
+            <bounds x="48" y="26" width="177" height="52"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="6c91790e-83a0-4ebb-a284-00efb9a2c9be" targetConnections="f6f31065-90de-400b-a2a3-98f55fc47cf1 31dd8564-a60b-4796-b8d1-659e3decc25a 56bb66fa-1b72-453a-af8d-6f0ed6abc96d f7ba0d6a-45ce-43a7-8edd-3530b131fb39 0a4e9831-9aac-4ca2-bbdf-6fce8a94dd1f ab1bbc27-227a-4003-90c8-1ce14225b40d" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
+          <bounds x="24" y="192" width="274" height="272"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a2fd5820-6539-46a0-b3b2-f65d8ac785b8" source="6c91790e-83a0-4ebb-a284-00efb9a2c9be" target="7b9df1dc-b0d3-4906-90f7-f8d2da1a27db" archimateRelationship="65eeae27-537c-48c0-9390-455f475c2800"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="69c65fdd-406a-4850-bd97-7d4d021ff3c7" targetConnections="e7193bac-53ab-44b1-9e03-9463e0428853" archimateElement="a46b13f6-899f-4651-bccd-67685ea0ab9d">
+          <bounds x="384" y="300" width="194" height="103"/>
+          <sourceConnection xsi:type="archimate:Connection" id="dfde0745-363c-4032-8f78-afe07c477a98" source="69c65fdd-406a-4850-bd97-7d4d021ff3c7" target="755dc58f-82ca-4fe5-8ea6-56b1a2c7d715" archimateRelationship="32f934ac-0d3b-43d1-9f47-447f6e564ba7"/>
+          <sourceConnection xsi:type="archimate:Connection" id="31dd8564-a60b-4796-b8d1-659e3decc25a" source="69c65fdd-406a-4850-bd97-7d4d021ff3c7" target="6c91790e-83a0-4ebb-a284-00efb9a2c9be" archimateRelationship="00c4a55a-5ec6-42e1-91fc-de97c090c9ec"/>
+          <sourceConnection xsi:type="archimate:Connection" id="508b7b88-d883-4aac-bd17-bd0e69864e0a" source="69c65fdd-406a-4850-bd97-7d4d021ff3c7" target="b986d0c4-45fe-4baa-b006-aba11c603af6" archimateRelationship="6652b746-6c44-479c-b3e9-5f901199d7ef"/>
+          <child xsi:type="archimate:DiagramObject" id="b986d0c4-45fe-4baa-b006-aba11c603af6" targetConnections="508b7b88-d883-4aac-bd17-bd0e69864e0a" archimateElement="8efc3e85-150e-4e1d-91f5-8989b1c5b89f">
+            <bounds x="21" y="41" width="133" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="755dc58f-82ca-4fe5-8ea6-56b1a2c7d715" targetConnections="dfde0745-363c-4032-8f78-afe07c477a98" archimateElement="2cc22b82-8760-46b4-80cb-118fb3cb04ee" type="1">
+          <bounds x="384" y="216" width="194" height="43"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="eba2d6ab-1ae9-4826-a1a7-8d8bb2cf8a7a" targetConnections="37f93719-8ff0-44b9-a304-6d5cc060437b" archimateElement="b7b2aa18-f4d7-4341-945c-03837cb989a6" type="1">
+          <bounds x="384" y="492" width="194" height="55"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="6022a491-35d7-4a3f-ae24-24bb300f92af" targetConnections="e2aca254-2ccb-436d-8e7d-c461ece678ac" archimateElement="c2bcebbc-2082-490d-aa5f-8606e59e3833">
+          <bounds x="384" y="576" width="194" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="37f93719-8ff0-44b9-a304-6d5cc060437b" source="6022a491-35d7-4a3f-ae24-24bb300f92af" target="eba2d6ab-1ae9-4826-a1a7-8d8bb2cf8a7a" archimateRelationship="d965cc0d-8876-416d-a61a-e12259efd4f9"/>
+          <sourceConnection xsi:type="archimate:Connection" id="cc950717-c407-4c67-9a96-8bd51d1f2f3b" source="6022a491-35d7-4a3f-ae24-24bb300f92af" target="639f869a-edc1-4168-abd0-5a06948c1a12" archimateRelationship="c63e1909-e2fe-4516-b642-d6749c9ad79c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="56bb66fa-1b72-453a-af8d-6f0ed6abc96d" source="6022a491-35d7-4a3f-ae24-24bb300f92af" target="6c91790e-83a0-4ebb-a284-00efb9a2c9be" archimateRelationship="254d9661-8126-4963-8d40-e57116fa4186">
+            <bendpoint startX="-336" startY="8" endX="-4" endY="296"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="14277cae-6a81-4fcd-8de8-5c6334a3dd64" source="6022a491-35d7-4a3f-ae24-24bb300f92af" target="a9302198-10a3-4038-969c-9dfdcff16f80" archimateRelationship="bce71955-7d5f-4f3d-a47c-a5b0b5af71d8"/>
+          <child xsi:type="archimate:DiagramObject" id="639f869a-edc1-4168-abd0-5a06948c1a12" targetConnections="cc950717-c407-4c67-9a96-8bd51d1f2f3b" archimateElement="cc875beb-f4ff-4952-9600-5eae35fb0d10">
+            <bounds x="21" y="41" width="141" height="55"/>
+          </child>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="87300c9c-0ff9-4771-8156-90418d1324b0" fillColor="#fefc78" archimateElement="77d30d3e-5889-4267-ac13-43ae42eec1d1">
+        <bounds x="1476" y="36" width="309" height="1092"/>
+        <child xsi:type="archimate:DiagramObject" id="bfa672d1-4e7a-4536-b35f-420eb95bac20" targetConnections="27dbf779-5f7b-4b18-8a94-aeaf02080173" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
+          <bounds x="36" y="468" width="242" height="271"/>
+          <sourceConnection xsi:type="archimate:Connection" id="e1331fc1-cf54-4cc4-89f2-6e4372dfde80" source="bfa672d1-4e7a-4536-b35f-420eb95bac20" target="ae49b623-0131-4534-ada0-cf05bad4bafc" archimateRelationship="fec9ce18-5dfb-4483-b947-1d4dd4709b45"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="ae49b623-0131-4534-ada0-cf05bad4bafc" targetConnections="e1331fc1-cf54-4cc4-89f2-6e4372dfde80" archimateElement="0984a188-6642-400c-a42f-20277624eee9" type="1">
+          <bounds x="35" y="324" width="242" height="105"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="19c200e2-8c84-46f2-b3d7-5643aedb3c3c" fillColor="#fefc78" archimateElement="ead927f6-aada-4517-9de7-5dcb477a7e36">
+        <bounds x="1140" y="36" width="309" height="288"/>
+        <child xsi:type="archimate:DiagramObject" id="2b56216e-fc72-43b7-a8d0-630daec4efd4" targetConnections="e4d34f96-fbfc-4a3b-9f1c-3da69153955e" archimateElement="197d58a5-2131-41e0-8ec3-37bc46ed9b3d" type="1">
+          <bounds x="59" y="63" width="193" height="44"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="635904ab-a91d-4b00-9bb4-c16015fbb26f" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
+          <bounds x="59" y="144" width="193" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="ccdc1dfd-1b91-4a87-aea2-fe88a3345b33" source="635904ab-a91d-4b00-9bb4-c16015fbb26f" target="ffc413bd-f31b-44a5-9e86-bbef1e457a36" archimateRelationship="b85300bf-77ed-49c7-84a8-011be915cee2"/>
+          <sourceConnection xsi:type="archimate:Connection" id="0c22f1ea-cc97-4ff6-916c-741208b74508" source="635904ab-a91d-4b00-9bb4-c16015fbb26f" target="da032665-44b4-4f87-a701-d9149325abd9" archimateRelationship="885e9e6f-9da6-4924-8aaf-d8c5ab20552b"/>
+          <child xsi:type="archimate:DiagramObject" id="ffc413bd-f31b-44a5-9e86-bbef1e457a36" targetConnections="ccdc1dfd-1b91-4a87-aea2-fe88a3345b33" archimateElement="68e59636-1f53-4336-9cfd-64fa6acae825">
+            <bounds x="14" y="40" width="151" height="55"/>
+            <sourceConnection xsi:type="archimate:Connection" id="e4d34f96-fbfc-4a3b-9f1c-3da69153955e" source="ffc413bd-f31b-44a5-9e86-bbef1e457a36" target="2b56216e-fc72-43b7-a8d0-630daec4efd4" archimateRelationship="caab7f6b-ecb8-4257-85ef-bbff50ef681b"/>
+          </child>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="9e9ffd98-0a9e-4ebb-b4d6-62fb60a507eb" fillColor="#fefc78" archimateElement="0077ac29-da6d-426c-90a0-51e987d5f202">
+        <bounds x="792" y="36" width="309" height="1092"/>
+        <child xsi:type="archimate:DiagramObject" id="fb575ba6-e63f-4324-bb5e-84cd0a34f962" archimateElement="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349">
+          <bounds x="62" y="308" width="204" height="109"/>
+          <sourceConnection xsi:type="archimate:Connection" id="d59c6d5a-bc03-4176-b0cf-08b2799cca7b" source="fb575ba6-e63f-4324-bb5e-84cd0a34f962" target="d599fdeb-89ae-4337-9692-17f2d1f38ebe" archimateRelationship="e08143cb-a72b-4f01-b442-a8c905603be7"/>
+          <sourceConnection xsi:type="archimate:Connection" id="8492a6c8-0677-4d39-b3cc-359daeb21ae9" source="fb575ba6-e63f-4324-bb5e-84cd0a34f962" target="2e1bfa55-d629-44a6-8148-205f12fcecac" archimateRelationship="3dfc3dbf-5711-45b6-930a-0dc44678676a"/>
+          <sourceConnection xsi:type="archimate:Connection" id="0a4e9831-9aac-4ca2-bbdf-6fce8a94dd1f" source="fb575ba6-e63f-4324-bb5e-84cd0a34f962" target="6c91790e-83a0-4ebb-a284-00efb9a2c9be" archimateRelationship="5ad8159f-f033-40fd-977d-34f2694d728b">
+            <bendpoint startX="-212" startY="-2" endX="439" endY="-352"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="8d3ffb0e-2f13-445b-aebd-72a4cedee61c" source="fb575ba6-e63f-4324-bb5e-84cd0a34f962" target="967bb696-f8e1-4030-b34d-96998e18f4f7" archimateRelationship="ce8340df-c3fc-4a8d-9987-b2f1dff90bcf">
+            <bendpoint startX="160" startY="-1" endX="-168" endY="-173"/>
+            <bendpoint startX="160" startY="155" endX="-168" endY="-17"/>
+          </sourceConnection>
+          <child xsi:type="archimate:DiagramObject" id="2e1bfa55-d629-44a6-8148-205f12fcecac" targetConnections="8492a6c8-0677-4d39-b3cc-359daeb21ae9" archimateElement="fede8dba-b24e-4347-9487-e9901da917f9">
+            <bounds x="22" y="52" width="148" height="47"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="d599fdeb-89ae-4337-9692-17f2d1f38ebe" targetConnections="d59c6d5a-bc03-4176-b0cf-08b2799cca7b" archimateElement="5647d2da-812c-4a0f-af6e-bac94daa4aeb" type="1">
+          <bounds x="60" y="216" width="204" height="55"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="d899fa65-d651-479e-acb7-50d34e958129" targetConnections="6079b8ae-efbe-482f-a0f5-fe99c85e969a d0c5b677-1bc6-433b-af31-d80505555e73" archimateElement="8532f211-fbcb-4255-a32d-91871c7336be">
+          <bounds x="60" y="924" width="205" height="60"/>
+          <sourceConnection xsi:type="archimate:Connection" id="f7ba0d6a-45ce-43a7-8edd-3530b131fb39" source="d899fa65-d651-479e-acb7-50d34e958129" target="6c91790e-83a0-4ebb-a284-00efb9a2c9be" archimateRelationship="b8077982-bc5b-42e6-baad-9a371e82443c">
+            <bendpoint startX="-186" startY="6" endX="464" endY="248"/>
+            <bendpoint startX="-186" startY="-138" endX="464" endY="104"/>
+          </sourceConnection>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="f324226f-eb60-41b2-aa0d-7728875e4148" targetConnections="8c613f2e-20da-4357-8755-17e63fb870dd" archimateElement="98f08e2a-55bb-4cf3-88f8-a72c328068e1">
+          <bounds x="60" y="720" width="205" height="100"/>
+          <sourceConnection xsi:type="archimate:Connection" id="5c2ff071-b25e-4d0b-a3a1-15b8977b67be" source="f324226f-eb60-41b2-aa0d-7728875e4148" target="a88322d4-e51b-401d-af95-c63cec15807d" archimateRelationship="f4d55798-6548-4f2b-8a36-dfb103680504"/>
+          <sourceConnection xsi:type="archimate:Connection" id="6079b8ae-efbe-482f-a0f5-fe99c85e969a" source="f324226f-eb60-41b2-aa0d-7728875e4148" target="d899fa65-d651-479e-acb7-50d34e958129" archimateRelationship="4ccd9580-1076-4ab8-9e7c-51b10d00aa48">
+            <bendpoint startX="-78" startY="106" endX="-78" endY="-78"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="e74d7335-2fdc-4df4-9d4a-0ddfb4cba20c" source="f324226f-eb60-41b2-aa0d-7728875e4148" target="43f9954c-707e-46d8-a6ae-82de12ed603a" archimateRelationship="b1837450-f7fb-4eb5-8d35-95206ec0ad1c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="e7193bac-53ab-44b1-9e03-9463e0428853" source="f324226f-eb60-41b2-aa0d-7728875e4148" target="69c65fdd-406a-4850-bd97-7d4d021ff3c7" archimateRelationship="dbe8aa22-0fa9-4cf4-9585-78e68a698731"/>
+          <child xsi:type="archimate:DiagramObject" id="a88322d4-e51b-401d-af95-c63cec15807d" targetConnections="5c2ff071-b25e-4d0b-a3a1-15b8977b67be" archimateElement="e573296a-1aac-4c71-871c-1baf2417c996">
+            <bounds x="17" y="45" width="152" height="47"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="48ac0cb7-88f3-45e3-8e38-ca34c9c00be0" archimateElement="16e6b406-99cd-4255-a1cc-6d6a8eb25fad">
+          <bounds x="108" y="852" width="72" height="40"/>
+          <sourceConnection xsi:type="archimate:Connection" id="19b5d045-058d-45f9-8de4-76a057c9f949" source="48ac0cb7-88f3-45e3-8e38-ca34c9c00be0" target="b9edd4da-b17b-41ee-93b6-3fbe1f99f7c3" archimateRelationship="a519c4a0-7f3d-4469-bb60-7d1404fa8ef0"/>
+          <sourceConnection xsi:type="archimate:Connection" id="8c613f2e-20da-4357-8755-17e63fb870dd" source="48ac0cb7-88f3-45e3-8e38-ca34c9c00be0" target="f324226f-eb60-41b2-aa0d-7728875e4148" archimateRelationship="96ac082a-4934-4e40-836a-8ad4ef304e95"/>
+          <sourceConnection xsi:type="archimate:Connection" id="d0c5b677-1bc6-433b-af31-d80505555e73" source="48ac0cb7-88f3-45e3-8e38-ca34c9c00be0" target="d899fa65-d651-479e-acb7-50d34e958129" archimateRelationship="f6b64b03-3d7d-4252-b62f-8eda3a01958a"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="b9edd4da-b17b-41ee-93b6-3fbe1f99f7c3" targetConnections="19b5d045-058d-45f9-8de4-76a057c9f949" archimateElement="40e6d34e-02c4-4b57-8af3-a3bfc8c89962" type="1">
+          <bounds x="216" y="852" width="84" height="40"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="fdcc5cfe-e574-46e0-84e5-f7fcd8167918" targetConnections="ce386721-9d91-4789-95b2-56eaca7b431a" archimateElement="83a086f5-68c0-475d-88e8-c53fc033a533" type="1">
+        <bounds x="853" y="479" width="205" height="43"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="4af0c929-899e-44df-b935-22a3a14da365" targetConnections="45187e85-f609-4271-90cf-9fdd91f0ac61" archimateElement="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe">
+        <bounds x="852" y="553" width="205" height="113"/>
+        <sourceConnection xsi:type="archimate:Connection" id="abb67a42-cfb1-4274-bbbe-1f6ce6fa09fc" source="4af0c929-899e-44df-b935-22a3a14da365" target="934c187c-a9a2-46ba-83dd-7dc2b773841e" archimateRelationship="3ca5b18c-b380-4be6-95f6-d6301b907ef5"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ce386721-9d91-4789-95b2-56eaca7b431a" source="4af0c929-899e-44df-b935-22a3a14da365" target="fdcc5cfe-e574-46e0-84e5-f7fcd8167918" archimateRelationship="8d9b2549-3ec1-40a7-a2bf-709d6c667325"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ab1bbc27-227a-4003-90c8-1ce14225b40d" source="4af0c929-899e-44df-b935-22a3a14da365" target="6c91790e-83a0-4ebb-a284-00efb9a2c9be" archimateRelationship="6188230a-d639-46ea-9351-4bd0e798f98e">
+          <bendpoint startX="-305" startY="16" endX="344" endY="-124"/>
+        </sourceConnection>
+        <child xsi:type="archimate:DiagramObject" id="934c187c-a9a2-46ba-83dd-7dc2b773841e" targetConnections="abb67a42-cfb1-4274-bbbe-1f6ce6fa09fc" archimateElement="10cb9a93-25d4-4da1-8964-c183b3ff910c">
+          <bounds x="20" y="47" width="152" height="55"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="63c05fe3-0295-40fb-9456-9239452182f3" fillColor="#fefc78" archimateElement="ad5945bc-e137-4d97-8af6-2a0752cd75d5">
+        <bounds x="1140" y="348" width="309" height="780"/>
+        <child xsi:type="archimate:DiagramObject" id="967bb696-f8e1-4030-b34d-96998e18f4f7" targetConnections="727b4ce3-3399-4a98-b4c7-fb6e0a9fc749 27d87744-1137-4681-b9f0-e5fff34f615b 8d3ffb0e-2f13-445b-aebd-72a4cedee61c" archimateElement="cd615d71-a688-420d-afd6-4583cdfc32f4">
+          <bounds x="48" y="132" width="193" height="181"/>
+          <sourceConnection xsi:type="archimate:Connection" id="f87104e6-f57a-43ea-be51-b5643898d46b" source="967bb696-f8e1-4030-b34d-96998e18f4f7" target="c4261c52-e31a-4343-afa3-73c65c72a0e7" archimateRelationship="aef2d174-8f6c-4ec4-bb5e-6ead3a646ff9"/>
+          <sourceConnection xsi:type="archimate:Connection" id="27dbf779-5f7b-4b18-8a94-aeaf02080173" source="967bb696-f8e1-4030-b34d-96998e18f4f7" target="bfa672d1-4e7a-4536-b35f-420eb95bac20" archimateRelationship="fe52d39f-721d-4207-8765-f42b54d38750"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="c9c9c6e3-4ec9-4095-90ec-cfbd05d0b86c" targetConnections="2666e3d6-1748-414e-a19f-0ac419469b05" archimateElement="9dc22627-f969-46c8-ac76-9f1ac9b35767" type="1">
+          <bounds x="49" y="350" width="194" height="43"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="43f9954c-707e-46d8-a6ae-82de12ed603a" targetConnections="e74d7335-2fdc-4df4-9d4a-0ddfb4cba20c" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
+          <bounds x="48" y="432" width="194" height="103"/>
+          <sourceConnection xsi:type="archimate:Connection" id="2666e3d6-1748-414e-a19f-0ac419469b05" source="43f9954c-707e-46d8-a6ae-82de12ed603a" target="c9c9c6e3-4ec9-4095-90ec-cfbd05d0b86c" archimateRelationship="0bef2725-e92f-4ade-887e-3bd76eab034c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="0fdc7f86-057a-44a3-9550-8ad0c2265b00" source="43f9954c-707e-46d8-a6ae-82de12ed603a" target="522b7c7c-4842-49e6-989c-e7a528a78c8d" archimateRelationship="dd6d220f-2e28-4568-9b32-05078dd07d50"/>
+          <sourceConnection xsi:type="archimate:Connection" id="45187e85-f609-4271-90cf-9fdd91f0ac61" source="43f9954c-707e-46d8-a6ae-82de12ed603a" target="4af0c929-899e-44df-b935-22a3a14da365" archimateRelationship="3de150e4-3c9e-45ad-9c44-fc2dccf967a3">
+            <bendpoint startX="-168" startY="-38" endX="163" endY="184"/>
+            <bendpoint startX="-168" startY="-218" endX="163" endY="4"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="727b4ce3-3399-4a98-b4c7-fb6e0a9fc749" source="43f9954c-707e-46d8-a6ae-82de12ed603a" target="967bb696-f8e1-4030-b34d-96998e18f4f7" archimateRelationship="4a660fa0-4e8f-431a-a526-0a5fe5523f1a">
+            <bendpoint startX="120" startY="-2" endX="120" endY="258"/>
+            <bendpoint startX="120" startY="-206" endX="120" endY="54"/>
+          </sourceConnection>
+          <child xsi:type="archimate:DiagramObject" id="522b7c7c-4842-49e6-989c-e7a528a78c8d" targetConnections="0fdc7f86-057a-44a3-9550-8ad0c2265b00" archimateElement="1a8879f8-06ce-4925-93ab-ff2222e347aa">
+            <bounds x="21" y="41" width="133" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="c4261c52-e31a-4343-afa3-73c65c72a0e7" targetConnections="f87104e6-f57a-43ea-be51-b5643898d46b" archimateElement="b39dc60a-f0ea-48a2-afe5-35c284ad66ed" type="1">
+          <bounds x="48" y="48" width="189" height="52"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="a9302198-10a3-4038-969c-9dfdcff16f80" targetConnections="14277cae-6a81-4fcd-8de8-5c6334a3dd64" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
+          <bounds x="48" y="643" width="194" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="1f92a31e-d5c6-494d-a748-4b12d7d16c40" source="a9302198-10a3-4038-969c-9dfdcff16f80" target="4a6d38b7-4fc3-4188-8eaa-66c3063c6a25" archimateRelationship="bf3a3e9b-d6d1-4989-8ef7-021d1f136913"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b5319e13-143f-4b3b-b865-304a074b791e" source="a9302198-10a3-4038-969c-9dfdcff16f80" target="09fd782a-2ea2-4889-a76c-07ac366e155a" archimateRelationship="67b2f7a1-c01c-464b-8caa-b4a9744f35ae"/>
+          <sourceConnection xsi:type="archimate:Connection" id="e2aca254-2ccb-436d-8e7d-c461ece678ac" source="a9302198-10a3-4038-969c-9dfdcff16f80" target="6022a491-35d7-4a3f-ae24-24bb300f92af" archimateRelationship="0e0d90ea-f06a-414b-9eab-4e425f96d110"/>
+          <sourceConnection xsi:type="archimate:Connection" id="27d87744-1137-4681-b9f0-e5fff34f615b" source="a9302198-10a3-4038-969c-9dfdcff16f80" target="967bb696-f8e1-4030-b34d-96998e18f4f7" archimateRelationship="b5ad019f-315d-47e7-8c45-7f6f38f6b57d">
+            <bendpoint startX="144" startY="2" endX="144" endY="474"/>
+            <bendpoint startX="144" startY="-430" endX="144" endY="42"/>
+          </sourceConnection>
+          <child xsi:type="archimate:DiagramObject" id="09fd782a-2ea2-4889-a76c-07ac366e155a" targetConnections="b5319e13-143f-4b3b-b865-304a074b791e" archimateElement="51eacaa9-ed7b-4307-915c-05a114b2a19d">
+            <bounds x="21" y="41" width="141" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="4a6d38b7-4fc3-4188-8eaa-66c3063c6a25" targetConnections="1f92a31e-d5c6-494d-a748-4b12d7d16c40" archimateElement="7c846708-edd4-4a3a-afad-a711b21abeb4" type="1">
+          <bounds x="48" y="564" width="194" height="55"/>
+        </child>
+      </child>
+      <documentation>This diagram shows a variation of how the application components defined in the ISA can be deployed to nodes in the technology architecture. In this variant the Member State of the Data Provider provides a National OOP Layer that realizes the functionality needed to connect to the TOOP network, i.e the TOOP Connector, SMP and AP.
+</documentation>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Component interface usage" id="5f327738-9b99-4b4e-81b8-e6c5d6eb81ce" viewpoint="application_usage">
+      <child xsi:type="archimate:DiagramObject" id="c97ee17b-f2b7-45f9-830c-d0cad5808b30" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75">
+        <bounds x="228" y="142" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="72d3f851-b080-49da-96f7-92d3d7d9c78b" source="c97ee17b-f2b7-45f9-830c-d0cad5808b30" target="dedca1c8-5558-4b28-8139-d296d905090c" archimateRelationship="8d84949c-da2f-456f-9c85-eb903765cea5"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="b0eb4a0a-aaad-45aa-a9e6-b3c0b75f70a3" archimateElement="0984a188-6642-400c-a42f-20277624eee9">
+        <bounds x="900" y="144" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="cf6a1c82-58cd-4b78-bb7f-f12621734217" source="b0eb4a0a-aaad-45aa-a9e6-b3c0b75f70a3" target="6e6eb356-a968-451e-b9b9-3bcfe715231f" archimateRelationship="590cb032-5e90-43cf-a05e-46eaa0beefcc"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="ddbfa4c7-02dc-41f1-b283-452b5bd542e9" targetConnections="100a8f9e-844b-4d2f-94a7-2bbfc64a90bf" archimateElement="2cc22b82-8760-46b4-80cb-118fb3cb04ee">
+        <bounds x="360" y="408" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="d029ad23-7e06-403c-ad58-c30abad46560" source="ddbfa4c7-02dc-41f1-b283-452b5bd542e9" target="ac39be51-8098-47f7-b748-c096150e4684" archimateRelationship="6d237ab5-76b1-4476-b103-6b13be7e111e"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e9ae598f-e7d0-4f66-acb8-43842f8ec67e" source="ddbfa4c7-02dc-41f1-b283-452b5bd542e9" target="a8e58b90-7af1-4567-ab99-a0038a7ee83a" archimateRelationship="3da7936f-6219-4b92-b91e-963e7d0ee505"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="81667bc2-d060-4e6c-a283-7e998cc2ec6d" targetConnections="46a5456d-fcc9-4d58-9d08-bd893f405fe8" archimateElement="9dc22627-f969-46c8-ac76-9f1ac9b35767">
+        <bounds x="768" y="408" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="df758b72-bbaa-40ec-b8fd-530fa5e317b0" source="81667bc2-d060-4e6c-a283-7e998cc2ec6d" target="6b6a639f-7ef9-4926-aa21-76baff299084" archimateRelationship="8ffa6c14-acbc-4d8e-bd8b-62a44994bb82"/>
+        <sourceConnection xsi:type="archimate:Connection" id="b5b41742-beb9-4b27-9351-efad62ee98f1" source="81667bc2-d060-4e6c-a283-7e998cc2ec6d" target="1f031889-9118-4957-ba96-5f3e305e2389" archimateRelationship="8815aa98-d51a-4b9c-ab71-3eb2eee94558"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="dedca1c8-5558-4b28-8139-d296d905090c" targetConnections="72d3f851-b080-49da-96f7-92d3d7d9c78b 69a48aa8-7b8f-4118-b6a7-ebb8e7ec13f1 c2b15eea-7a53-4363-b2b5-2cb550de404d efbe1a72-62c3-47b5-805c-b3c3b96ee91a 60b28da1-e7bb-4eb1-98b5-daff4b9f042d b73fa031-3ba9-44d4-b502-e3ad9b760ae8" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49">
+        <bounds x="228" y="276" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="6e6eb356-a968-451e-b9b9-3bcfe715231f" targetConnections="cf6a1c82-58cd-4b78-bb7f-f12621734217 2bde6987-7ac3-4757-9445-8cde9e1aed70 c9228d6e-e296-4670-a782-af6d01fdb0ff 8b5697a0-f085-47d7-87bf-7e21115c44a3 51f82e42-19ca-4f8b-8993-f7514d69a3a1" archimateElement="b39dc60a-f0ea-48a2-afe5-35c284ad66ed">
+        <bounds x="900" y="276" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="5cd0bec1-a5a1-4cb4-a6ad-640063856180" targetConnections="5cf5e1bb-3a9d-47dd-a877-a02a8dfb1f44 aed629e7-9f18-4ddd-af06-1c882a28fb9d" archimateElement="83a086f5-68c0-475d-88e8-c53fc033a533">
+        <bounds x="576" y="324" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="70c8e5b0-f218-489b-b535-9b2e59c23377" source="5cd0bec1-a5a1-4cb4-a6ad-640063856180" target="17d0621a-fd05-4979-93d3-66e58100ba61" archimateRelationship="9c40fea9-bda0-4ab6-9802-98600c801a46"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="abfe972b-8b54-47b6-a84b-c92c10a48f02" targetConnections="8c9748f8-cf5f-4733-9a13-bbe0a2f05077" archimateElement="b7b2aa18-f4d7-4341-945c-03837cb989a6">
+        <bounds x="228" y="552" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="b72c91d9-2775-4c3d-84c7-40648291108f" source="abfe972b-8b54-47b6-a84b-c92c10a48f02" target="7534b977-a477-4b81-9736-91a705d6aed6" archimateRelationship="06652625-b173-41c6-83a4-d51177cfa659"/>
+        <sourceConnection xsi:type="archimate:Connection" id="2f469f0b-5e20-4983-a146-9790ec26271c" source="abfe972b-8b54-47b6-a84b-c92c10a48f02" target="f8d67d33-23c1-4ed4-8642-3b2e70a72cf9" archimateRelationship="c9b7f6ce-d6ad-4680-8ea6-10c7ea24e8f5"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="4ca89db2-2487-4039-b5c3-3f8dd1c2b98e" targetConnections="929e072c-ec11-495a-94e4-54fbbcebf766" archimateElement="7c846708-edd4-4a3a-afad-a711b21abeb4">
+        <bounds x="900" y="552" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="781bdb7d-4b4b-4c52-9bf2-c9cb8da230c0" source="4ca89db2-2487-4039-b5c3-3f8dd1c2b98e" target="05469a7b-3dc3-4405-ae5b-1e5401026693" archimateRelationship="4c4c61ca-522d-4c69-a239-b7e3a4b481ed"/>
+        <sourceConnection xsi:type="archimate:Connection" id="32659f9d-6be2-4a57-a768-4a3fdf6f26cd" source="4ca89db2-2487-4039-b5c3-3f8dd1c2b98e" target="80e0645e-04a5-4f24-a936-9ded64ef007d" archimateRelationship="519cb351-5dfc-4e2e-84cc-901bc0682ae2"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="11c2b488-f0cf-486b-af0d-770c1d91c92f" archimateElement="5647d2da-812c-4a0f-af6e-bac94daa4aeb">
+        <bounds x="576" y="144" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="936ce796-86e5-4ca7-a419-e1d004156467" source="11c2b488-f0cf-486b-af0d-770c1d91c92f" target="97fb2524-bfad-41a1-9bcf-922a446d6ac7" archimateRelationship="28c76209-3507-4429-a9dd-d9da1da7c400"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="c101d0d8-00d8-4dcb-bb15-18f651c71316" archimateElement="40e6d34e-02c4-4b57-8af3-a3bfc8c89962">
+        <bounds x="576" y="492" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="f79d22fe-b436-4fdb-ab39-29d358e57be7" source="c101d0d8-00d8-4dcb-bb15-18f651c71316" target="62f8bbe8-918e-470b-83f1-5abd6844b520" archimateRelationship="d2f13c19-7c1c-4bce-99c1-c48fa70abb1a"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="7534b977-a477-4b81-9736-91a705d6aed6" targetConnections="b72c91d9-2775-4c3d-84c7-40648291108f" archimateElement="835ff675-a050-43e1-b604-bf34f420b4b4" type="1">
+        <bounds x="392" y="576" width="42" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="929e072c-ec11-495a-94e4-54fbbcebf766" source="7534b977-a477-4b81-9736-91a705d6aed6" target="4ca89db2-2487-4039-b5c3-3f8dd1c2b98e" archimateRelationship="ad7aeacf-4597-4016-8f4d-18e840290654"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="05469a7b-3dc3-4405-ae5b-1e5401026693" targetConnections="781bdb7d-4b4b-4c52-9bf2-c9cb8da230c0" archimateElement="02845e0f-b515-434b-acee-3cb30c0a38d5" type="1">
+        <bounds x="828" y="552" width="42" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8c9748f8-cf5f-4733-9a13-bbe0a2f05077" source="05469a7b-3dc3-4405-ae5b-1e5401026693" target="abfe972b-8b54-47b6-a84b-c92c10a48f02" archimateRelationship="ae70350c-af50-4e6d-9063-dde12aa28cad"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="f8d67d33-23c1-4ed4-8642-3b2e70a72cf9" targetConnections="2f469f0b-5e20-4983-a146-9790ec26271c" archimateElement="9a9db724-b4cf-4cf5-83e4-dab836fac332" type="1">
+        <bounds x="267" y="478" width="42" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="69a48aa8-7b8f-4118-b6a7-ebb8e7ec13f1" source="f8d67d33-23c1-4ed4-8642-3b2e70a72cf9" target="dedca1c8-5558-4b28-8139-d296d905090c" archimateRelationship="33626729-1190-4f6e-b71e-1f475b639a6d"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="62f8bbe8-918e-470b-83f1-5abd6844b520" targetConnections="f79d22fe-b436-4fdb-ab39-29d358e57be7" archimateElement="1a514cf5-70e0-49af-b794-9ef63c488161" type="1">
+        <bounds x="612" y="420" width="42" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="46a5456d-fcc9-4d58-9d08-bd893f405fe8" source="62f8bbe8-918e-470b-83f1-5abd6844b520" target="81667bc2-d060-4e6c-a283-7e998cc2ec6d" archimateRelationship="82fb773e-adcc-4992-b9c0-ec9da83600ba"/>
+        <sourceConnection xsi:type="archimate:Connection" id="100a8f9e-844b-4d2f-94a7-2bbfc64a90bf" source="62f8bbe8-918e-470b-83f1-5abd6844b520" target="ddbfa4c7-02dc-41f1-b283-452b5bd542e9" archimateRelationship="989c24da-5eea-45fb-9700-84160bc24552"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="6b6a639f-7ef9-4926-aa21-76baff299084" targetConnections="df758b72-bbaa-40ec-b8fd-530fa5e317b0" archimateElement="d025299b-1e44-4c5c-8a92-46eceda4a5c5" type="1">
+        <bounds x="780" y="339" width="42" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5cf5e1bb-3a9d-47dd-a877-a02a8dfb1f44" source="6b6a639f-7ef9-4926-aa21-76baff299084" target="5cd0bec1-a5a1-4cb4-a6ad-640063856180" archimateRelationship="8c61761f-36e7-41a5-92ca-9dc20b1fc934"/>
+        <sourceConnection xsi:type="archimate:Connection" id="c2b15eea-7a53-4363-b2b5-2cb550de404d" source="6b6a639f-7ef9-4926-aa21-76baff299084" target="dedca1c8-5558-4b28-8139-d296d905090c" archimateRelationship="09577d17-e481-4b1a-903a-7999a077b002">
+          <bendpoint startX="3" startY="-57" endX="516" endY="-3"/>
+        </sourceConnection>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="ac39be51-8098-47f7-b748-c096150e4684" targetConnections="d029ad23-7e06-403c-ad58-c30abad46560" archimateElement="7389032a-cc99-482b-a771-d84f92fd8119" type="1">
+        <bounds x="433" y="339" width="42" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="aed629e7-9f18-4ddd-af06-1c882a28fb9d" source="ac39be51-8098-47f7-b748-c096150e4684" target="5cd0bec1-a5a1-4cb4-a6ad-640063856180" archimateRelationship="71a58fc5-548d-42d7-bd03-d6f593b582a6"/>
+        <sourceConnection xsi:type="archimate:Connection" id="2bde6987-7ac3-4757-9445-8cde9e1aed70" source="ac39be51-8098-47f7-b748-c096150e4684" target="6e6eb356-a968-451e-b9b9-3bcfe715231f" archimateRelationship="1bb82133-972d-42be-a0fc-21c398424af0">
+          <bendpoint startX="-10" startY="-81" endX="-516" endY="-27"/>
+        </sourceConnection>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="17d0621a-fd05-4979-93d3-66e58100ba61" targetConnections="70c8e5b0-f218-489b-b535-9b2e59c23377" archimateElement="c62c44e5-96f4-4823-b5d1-f0c8af91938a" type="1">
+        <bounds x="492" y="312" width="42" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="efbe1a72-62c3-47b5-805c-b3c3b96ee91a" source="17d0621a-fd05-4979-93d3-66e58100ba61" target="dedca1c8-5558-4b28-8139-d296d905090c" archimateRelationship="cbe943d0-243b-4802-b73b-ea9e5942ceff"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="1f031889-9118-4957-ba96-5f3e305e2389" targetConnections="b5b41742-beb9-4b27-9351-efad62ee98f1" archimateElement="885f43a3-57ff-4952-9f8b-146840faee3d" type="1">
+        <bounds x="840" y="339" width="42" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="c9228d6e-e296-4670-a782-af6d01fdb0ff" source="1f031889-9118-4957-ba96-5f3e305e2389" target="6e6eb356-a968-451e-b9b9-3bcfe715231f" archimateRelationship="a24ea6e6-04e1-4269-ba3e-10c4f06faefe">
+          <bendpoint startX="75" startY="3" endX="-24" endY="57"/>
+        </sourceConnection>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="a8e58b90-7af1-4567-ab99-a0038a7ee83a" targetConnections="e9ae598f-e7d0-4f66-acb8-43842f8ec67e" archimateElement="db1afbbe-2192-454f-8c54-7eb10861cc29" type="1">
+        <bounds x="372" y="339" width="42" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="60b28da1-e7bb-4eb1-98b5-daff4b9f042d" source="a8e58b90-7af1-4567-ab99-a0038a7ee83a" target="dedca1c8-5558-4b28-8139-d296d905090c" archimateRelationship="03081380-6feb-4459-813c-40df0f4d4be1">
+          <bendpoint startX="-93" startY="3" endX="51" endY="55"/>
+        </sourceConnection>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="80e0645e-04a5-4f24-a936-9ded64ef007d" targetConnections="32659f9d-6be2-4a57-a768-4a3fdf6f26cd" archimateElement="5d5f141b-0288-4b84-923f-b186eb23c67b" type="1">
+        <bounds x="948" y="480" width="42" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8b5697a0-f085-47d7-87bf-7e21115c44a3" source="80e0645e-04a5-4f24-a936-9ded64ef007d" target="6e6eb356-a968-451e-b9b9-3bcfe715231f" archimateRelationship="e8aeb9c9-677c-4e53-a466-5b1ec18d933a"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="97fb2524-bfad-41a1-9bcf-922a446d6ac7" targetConnections="936ce796-86e5-4ca7-a419-e1d004156467" archimateElement="524e0622-8fa1-4688-998f-e378e2d50dd2" type="1">
+        <bounds x="615" y="228" width="42" height="37"/>
+        <sourceConnection xsi:type="archimate:Connection" id="51f82e42-19ca-4f8b-8993-f7514d69a3a1" source="97fb2524-bfad-41a1-9bcf-922a446d6ac7" target="6e6eb356-a968-451e-b9b9-3bcfe715231f" archimateRelationship="6d569d38-6a65-486e-9624-ea19776a3b5a">
+          <bendpoint startX="302" startY="1" endX="-22" endY="-56"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="b73fa031-3ba9-44d4-b502-e3ad9b760ae8" source="97fb2524-bfad-41a1-9bcf-922a446d6ac7" target="dedca1c8-5558-4b28-8139-d296d905090c" archimateRelationship="bd03205a-e3b7-40e5-9764-3096d03674ab">
+          <bendpoint startX="-316" endX="32" endY="-57"/>
+        </sourceConnection>
+      </child>
+      <documentation>This diagram shows how the interfaces of the components are used when an evidence is exchanged between the Data Consumer and Data Provider. For each of these interface a security and trust analysis should be made.</documentation>
     </element>
   </folder>
 </archimate:model>

--- a/TOOP Architecture.archimate
+++ b/TOOP Architecture.archimate
@@ -5,15 +5,15 @@
     <element xsi:type="archimate:BusinessRole" name="User" id="fad8e664-4fad-4d4a-9a10-74c710c3b97a"/>
     <element xsi:type="archimate:BusinessRole" name="Data Consumer" id="9f9e46c6-ae4d-4a85-9885-c350181a7f9e"/>
     <element xsi:type="archimate:BusinessProcess" name="Execute Public Service" id="0d63a4ac-c4aa-40ff-8653-14d682a5531f"/>
-    <element xsi:type="archimate:BusinessProcess" name="Ask for data retrieval from other authority" id="445db22c-cb8a-48ea-81c6-dbc99399fa91"/>
+    <element xsi:type="archimate:BusinessProcess" name="Ask user for confirmation of evidence retrieval from other authority" id="445db22c-cb8a-48ea-81c6-dbc99399fa91"/>
     <element xsi:type="archimate:BusinessProcess" name="Ask for consent to retrieve personal data" id="542c9c45-139b-415b-9888-5dbbb4bb03ff"/>
-    <element xsi:type="archimate:BusinessProcess" name="Find and retrieve data from data provider" id="6bc58486-8d4c-49ae-acf9-5113c4688d0a"/>
-    <element xsi:type="archimate:BusinessEvent" name="Need for data already provided to data provider" id="5711d3c1-4238-4c90-af05-6238458b576b"/>
+    <element xsi:type="archimate:BusinessProcess" name="Find and retrieve evidence from data provider" id="6bc58486-8d4c-49ae-acf9-5113c4688d0a"/>
+    <element xsi:type="archimate:BusinessEvent" name="Need for evidence" id="5711d3c1-4238-4c90-af05-6238458b576b"/>
     <element xsi:type="archimate:BusinessObject" name="Explicit Request" id="53ac573b-bada-4a1a-8eb5-debaa24d3809"/>
     <element xsi:type="archimate:BusinessObject" name="Consent" id="95d4f54d-d61a-494e-9ae7-f04687e1e0f7"/>
     <element xsi:type="archimate:BusinessProcess" name="Authenticate user" id="9c559689-3063-4980-ba54-6c6571fdfafa"/>
-    <element xsi:type="archimate:BusinessObject" name="Identity" id="030bea1c-c47c-49f8-89d6-8cd8d8929cf8"/>
-    <element xsi:type="archimate:BusinessObject" name="Data Request" id="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508"/>
+    <element xsi:type="archimate:BusinessObject" name="Identity attributes" id="030bea1c-c47c-49f8-89d6-8cd8d8929cf8"/>
+    <element xsi:type="archimate:BusinessObject" name="Evidence Request" id="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508"/>
     <element xsi:type="archimate:BusinessRole" name="Data Provider" id="8a97d09b-a4db-47f1-bf36-d3dc84e0f234"/>
     <element xsi:type="archimate:BusinessService" name="eDelivery Service" id="ef17e0d7-bed7-4f7f-8462-f4d07d2a2d69"/>
     <element xsi:type="archimate:BusinessRole" name="Access Point Provider (DC)" id="95eb3e6f-f928-49ae-8c1e-008b3a677158"/>
@@ -21,14 +21,21 @@
     <element xsi:type="archimate:BusinessRole" name="Access Point Provider (DP)" id="95b78242-cd23-445d-af51-41409c4f20c6"/>
     <element xsi:type="archimate:BusinessObject" name="AS4 Message" id="40566433-b208-4b0b-ab2f-ac56863fa713"/>
     <element xsi:type="archimate:BusinessProcess" name="Provide data" id="a2307ac8-440f-4e9d-94ec-310d20b36df8"/>
-    <element xsi:type="archimate:BusinessProcess" name="FInd data of user" id="727c636e-94a8-4af8-9af6-04bcec1e3143"/>
+    <element xsi:type="archimate:BusinessProcess" name="FInd data of user" id="727c636e-94a8-4af8-9af6-04bcec1e3143">
+      <documentation>This process step involves &quot;Record Matching&quot;, i.e. finding the evidence for the user based on the provided identity attributes.</documentation>
+    </element>
     <element xsi:type="archimate:BusinessProcess" name="Check legitimacy of request" id="52a66463-82a1-4de1-8405-57da30cbfd3b"/>
     <element xsi:type="archimate:BusinessProcess" name="Send response" id="c89398a3-0a96-4369-a8c0-b7fbbccf232c"/>
-    <element xsi:type="archimate:BusinessObject" name="Requested Data" id="1b0685dc-27ec-49a5-8dad-448356ff10ef"/>
+    <element xsi:type="archimate:BusinessObject" name="Requested Evidence" id="1b0685dc-27ec-49a5-8dad-448356ff10ef"/>
     <element xsi:type="archimate:BusinessRole" name="Certificate Authority" id="80a99a8e-fb62-4313-a07a-806f36458f24"/>
     <element xsi:type="archimate:BusinessRole" name="Competent Authority" id="850c5bb7-f0c1-45ba-871f-daa2fd9c4be3"/>
     <element xsi:type="archimate:BusinessRole" name="SMP Service Provider" id="cd190536-c093-4a49-99d6-a8cbb5de0876"/>
     <element xsi:type="archimate:BusinessRole" name="Access Point Provider" id="487a932a-1d31-45a6-83d3-4a9a28854c90"/>
+    <element xsi:type="archimate:BusinessActor" name="Competent Authority" id="cfadf0df-e7a6-4465-ba12-5ad6e915a525"/>
+    <element xsi:type="archimate:BusinessActor" name="Member State" id="2c9f4633-1900-40f9-9ea1-3758509a1381"/>
+    <element xsi:type="archimate:BusinessActor" name="Member State (copy)" id="ca3c1a83-d099-4a3c-b28f-8cc3bb8738b8"/>
+    <element xsi:type="archimate:BusinessActor" name="TOOP Network Management" id="0077ac29-da6d-426c-90a0-51e987d5f202"/>
+    <element xsi:type="archimate:BusinessProcess" name="Process evidence" id="8af6862d-cfee-417d-82d1-d92058948e4a"/>
   </folder>
   <folder name="Application" id="14ecd00d-adbb-4a53-8985-eb26c7380878" type="application">
     <element xsi:type="archimate:ApplicationComponent" name="Data Consumer System" id="c69264a3-6790-4058-8056-d7654ae77a75"/>
@@ -55,24 +62,26 @@
     <element xsi:type="archimate:ApplicationComponent" name="AS Access Point (DC)" id="b7b2aa18-f4d7-4341-945c-03837cb989a6"/>
     <element xsi:type="archimate:ApplicationComponent" name="AS Access Point (DP)" id="7c846708-edd4-4a3a-afad-a711b21abeb4"/>
     <element xsi:type="archimate:ApplicationComponent" name="eIDAS Node" id="197d58a5-2131-41e0-8ec3-37bc46ed9b3d"/>
-    <element xsi:type="archimate:ApplicationComponent" name="Semantic Mapping Service" id="5647d2da-812c-4a0f-af6e-bac94daa4aeb"/>
+    <element xsi:type="archimate:ApplicationComponent" name="Semantic Service" id="5647d2da-812c-4a0f-af6e-bac94daa4aeb"/>
     <element xsi:type="archimate:DataObject" name="Competent Authority Certificate" id="cf368aea-2632-472e-93fd-9283417f526a"/>
     <element xsi:type="archimate:ApplicationComponent" name="SMP" id="807ead6b-5921-4901-85ba-5aec2455149c"/>
     <element xsi:type="archimate:DataObject" name="SMP Provider Certificate" id="8fce2f71-c778-48e6-8182-fc92696647d7"/>
     <element xsi:type="archimate:DataObject" name="Trust List" id="47712a4b-32c0-401d-887e-b659374a7166"/>
     <element xsi:type="archimate:ApplicationComponent" name="BDXL" id="40e6d34e-02c4-4b57-8af3-a3bfc8c89962"/>
-    <element xsi:type="archimate:ApplicationService" name="Register SMP" id="c96b9e24-98ca-466d-a2d2-84993b348d01"/>
+    <element xsi:type="archimate:ApplicationService" name="SMP Registration" id="c96b9e24-98ca-466d-a2d2-84993b348d01"/>
     <element xsi:type="archimate:DataObject" name="SMP Certificate" id="013f493e-1497-459f-96e7-e31942157778"/>
-    <element xsi:type="archimate:ApplicationProcess" name="SMP Validation" id="ac982ce3-98bb-468b-a594-1f4463e9babb"/>
-    <element xsi:type="archimate:ApplicationProcess" name="SMP Registration" id="46993d29-c622-4da9-a827-613b19e05632"/>
+    <element xsi:type="archimate:ApplicationProcess" name="Validate SMP" id="ac982ce3-98bb-468b-a594-1f4463e9babb"/>
+    <element xsi:type="archimate:ApplicationProcess" name="Register SMP" id="46993d29-c622-4da9-a827-613b19e05632"/>
     <element xsi:type="archimate:ApplicationProcess" name="Publish SMP location" id="5039ff23-50cf-45d4-adba-913033c25087"/>
-    <element xsi:type="archimate:ApplicationService" name="Publish meta-data" id="f32e715b-c735-4cf9-95d5-442183d6a78e"/>
+    <element xsi:type="archimate:ApplicationService" name="Providing meta-data" id="f32e715b-c735-4cf9-95d5-442183d6a78e"/>
     <element xsi:type="archimate:ApplicationFunction" name="Routing Metadata Discovery" id="ff508064-92fe-4e22-af13-af192add8998"/>
     <element xsi:type="archimate:DataObject" name="Signed meta-data" id="00da5f43-6209-4b90-98b6-66f241f28bc1"/>
     <element xsi:type="archimate:DataObject" name="AP Provider (DC) Certificate" id="c0b1a8e1-f208-4c52-ba6e-5b1831bd8ff8"/>
     <element xsi:type="archimate:DataObject" name="AS4 Receipt" id="b05b5406-553d-4861-9f0d-9dfdce3907fc"/>
     <element xsi:type="archimate:DataObject" name="AP Provider (DP) Certificate" id="145becdc-6985-48c4-a520-a423ae80ec59"/>
     <element xsi:type="archimate:DataObject" name="SMP Meta-data" id="108c2382-e2bf-4950-93ba-10e61c915592"/>
+    <element xsi:type="archimate:ApplicationComponent" name="AS Access Point (DC) (copy)" id="d919bb01-6f6e-4b59-88f1-8764638de3f4"/>
+    <element xsi:type="archimate:DataObject" name="Signed meta-data (copy)" id="6ec3236f-3e73-4100-8e18-cd783f289ba6"/>
   </folder>
   <folder name="Technology &amp; Physical" id="b37c3ce8-e970-4b27-9c32-83c4e3835745" type="technology">
     <element xsi:type="archimate:Node" name="Data Consumer System" id="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
@@ -104,17 +113,25 @@
     <element xsi:type="archimate:CommunicationNetwork" name="eIDAS network" id="ec24ee51-08ed-465b-a883-ae6776b24eb8"/>
     <element xsi:type="archimate:CommunicationNetwork" name="National Network of DP" id="f925eb37-dc1e-4ab2-a179-808b431dcb0c"/>
     <element xsi:type="archimate:Node" name="Central Trust List Server" id="64672752-1b6b-4fd1-ab2f-9f8eff29d024"/>
-    <element xsi:type="archimate:Node" name="Member State Trust List Server" id="17bc30f6-6291-43bc-b2e5-ef5202bc18e4"/>
-    <element xsi:type="archimate:Node" name="Member State Trust List Server (copy)" id="819e7e8c-a185-4b7b-b205-940fefcfe408"/>
+    <element xsi:type="archimate:Node" name="DC's MS Trust List Server" id="17bc30f6-6291-43bc-b2e5-ef5202bc18e4"/>
+    <element xsi:type="archimate:Node" name="DP's MS Trust List Server" id="819e7e8c-a185-4b7b-b205-940fefcfe408"/>
+    <element xsi:type="archimate:Node" name="Access Point (DC) (copy)" id="f3fb9603-2d7a-4264-985f-ad75532816c9"/>
+    <element xsi:type="archimate:SystemSoftware" name="AS4 Message Service Handler (copy)" id="70c184e2-dd66-4c98-8a3a-ec23190cff08"/>
   </folder>
   <folder name="Motivation" id="e3dd0cb4-7b89-407a-9393-dbb9f347b6ec" type="motivation"/>
   <folder name="Implementation &amp; Migration" id="e6f65253-9459-48a8-a9f0-e9755b2e86fc" type="implementation_migration"/>
   <folder name="Other" id="1f12370d-3436-4882-9244-fabf37f7c051" type="other">
     <element xsi:type="archimate:Junction" name="Junction" id="38b61099-7009-443e-b2df-761194403fc9"/>
     <element xsi:type="archimate:Junction" name="Junction" id="d4fc0cff-64bd-47c2-be39-0d20e234a2dd"/>
-    <element xsi:type="archimate:Location" name="DC's Member State" id="212f31b8-928f-4714-8aa2-542ecdb81468"/>
+    <element xsi:type="archimate:Location" name="Member State" id="212f31b8-928f-4714-8aa2-542ecdb81468">
+      <documentation>The Data Consumer MS</documentation>
+    </element>
     <element xsi:type="archimate:Location" name="Central" id="efbf9f7a-7b30-462f-a471-3cc2049014b5"/>
-    <element xsi:type="archimate:Location" name="DP's Member State" id="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac"/>
+    <element xsi:type="archimate:Location" name="Member State" id="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac">
+      <documentation>The Data Provider MS</documentation>
+    </element>
+    <element xsi:type="archimate:Junction" name="Junction" id="6f2885ed-f6ec-421e-ac59-ac6e834612e0"/>
+    <element xsi:type="archimate:Junction" name="Junction" id="bf0a70a9-46f0-42ae-95ec-ea1656923b9b"/>
   </folder>
   <folder name="Relations" id="581cce27-5db4-48ae-ad98-a7fe7eea68c3" type="relations">
     <element xsi:type="archimate:CompositionRelationship" id="46975254-c3e9-4883-8aa3-3169ed3d7c29" source="0d63a4ac-c4aa-40ff-8653-14d682a5531f" target="445db22c-cb8a-48ea-81c6-dbc99399fa91"/>
@@ -216,16 +233,9 @@
     <element xsi:type="archimate:CompositionRelationship" id="3dfc3dbf-5711-45b6-930a-0dc44678676a" source="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349" target="fede8dba-b24e-4347-9487-e9901da917f9"/>
     <element xsi:type="archimate:ServingRelationship" id="5ad8159f-f033-40fd-977d-34f2694d728b" source="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
     <element xsi:type="archimate:ServingRelationship" id="9102c6a7-d07f-4de0-94d7-273bb7bca236" source="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349" target="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e"/>
-    <element xsi:type="archimate:AggregationRelationship" id="30ba6a82-c6d3-4a27-83ce-9d8cde8750bd" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="a46b13f6-899f-4651-bccd-67685ea0ab9d"/>
-    <element xsi:type="archimate:AggregationRelationship" id="db710967-fa2b-4904-87d4-5d28e548a07d" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
-    <element xsi:type="archimate:AggregationRelationship" id="b57e920c-ff16-47af-8706-b277376ee747" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="c2bcebbc-2082-490d-aa5f-8606e59e3833"/>
     <element xsi:type="archimate:AggregationRelationship" id="f28c0a1d-12f1-4f22-9add-268879bc8a51" source="efbf9f7a-7b30-462f-a471-3cc2049014b5" target="8532f211-fbcb-4255-a32d-91871c7336be"/>
     <element xsi:type="archimate:AggregationRelationship" id="b42e098e-f8e9-48a6-9786-1de691e9e707" source="efbf9f7a-7b30-462f-a471-3cc2049014b5" target="98f08e2a-55bb-4cf3-88f8-a72c328068e1"/>
     <element xsi:type="archimate:AggregationRelationship" id="8061137c-057b-42fe-b50e-08493914d415" source="efbf9f7a-7b30-462f-a471-3cc2049014b5" target="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe"/>
-    <element xsi:type="archimate:AggregationRelationship" id="17b2804b-bcb2-400f-b93c-827ca8523d9e" source="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac" target="69efba2e-88ec-4e92-a231-8d4bb02b8abb"/>
-    <element xsi:type="archimate:AggregationRelationship" id="3fdeebe9-63d6-4c7f-911f-820cf135848c" source="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac" target="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e"/>
-    <element xsi:type="archimate:AggregationRelationship" id="a9609e08-a8e3-4e25-8f10-7e68029931d2" source="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac" target="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d"/>
-    <element xsi:type="archimate:AggregationRelationship" id="c801c856-c345-4a22-9a98-42569a3220bd" source="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac" target="ca49e61c-53cc-4599-b5fd-f30b80485328"/>
     <element xsi:type="archimate:AssociationRelationship" id="95c2def0-63c5-47e6-a79e-2ae528a5740d" source="556907f5-b628-43fb-845c-db9cb756483a" target="a46b13f6-899f-4651-bccd-67685ea0ab9d"/>
     <element xsi:type="archimate:AssociationRelationship" id="6ac270e4-3520-44ba-8784-77f217b03887" source="556907f5-b628-43fb-845c-db9cb756483a" target="cfe6f942-99a2-4512-bf58-9be6921adb78"/>
     <element xsi:type="archimate:AssociationRelationship" id="9063ad94-b467-48df-97c6-3d97233391ce" source="556907f5-b628-43fb-845c-db9cb756483a" target="c2bcebbc-2082-490d-aa5f-8606e59e3833"/>
@@ -248,7 +258,6 @@
     <element xsi:type="archimate:AssociationRelationship" id="0a90aced-35fd-499f-8aee-26de44bf636c" source="f925eb37-dc1e-4ab2-a179-808b431dcb0c" target="69efba2e-88ec-4e92-a231-8d4bb02b8abb"/>
     <element xsi:type="archimate:AssociationRelationship" id="6b11f94c-fad5-4ef3-acde-3a77b7cc9b4b" source="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
     <element xsi:type="archimate:AssociationRelationship" id="4565571a-58a5-4483-9551-4dc1600b45c1" source="f925eb37-dc1e-4ab2-a179-808b431dcb0c" target="ca49e61c-53cc-4599-b5fd-f30b80485328"/>
-    <element xsi:type="archimate:AggregationRelationship" id="8adf2b0b-3bd8-40ce-8a75-a5e29b7aaa84" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="556907f5-b628-43fb-845c-db9cb756483a"/>
     <element xsi:type="archimate:AggregationRelationship" id="8d84949c-da2f-456f-9c85-eb903765cea5" source="c69264a3-6790-4058-8056-d7654ae77a75" target="1480bf3c-d41d-4fea-827b-9ef9f79e6f49"/>
     <element xsi:type="archimate:RealizationRelationship" id="65eeae27-537c-48c0-9390-455f475c2800" source="cfe6f942-99a2-4512-bf58-9be6921adb78" target="c69264a3-6790-4058-8056-d7654ae77a75"/>
     <element xsi:type="archimate:RealizationRelationship" id="4d511da2-7df6-4beb-b47c-78b2f788e5f5" source="aae5673b-3220-4959-bd3b-a4351a94194d" target="5e3cba4d-6785-4a6a-80e7-ccabcb45c0e3"/>
@@ -271,8 +280,6 @@
     <element xsi:type="archimate:AggregationRelationship" id="70325378-0b5d-491e-9467-3d31f6fb6da7" source="47712a4b-32c0-401d-887e-b659374a7166" target="cf368aea-2632-472e-93fd-9283417f526a"/>
     <element xsi:type="archimate:CompositionRelationship" id="11ea2f70-8009-4b9d-b099-5e577fd85591" source="efbf9f7a-7b30-462f-a471-3cc2049014b5" target="d61e514e-6042-4efb-8e3a-ab4c7f021115"/>
     <element xsi:type="archimate:AssociationRelationship" id="b773c016-9fae-4909-8927-39901fdfbb37" source="64672752-1b6b-4fd1-ab2f-9f8eff29d024" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
-    <element xsi:type="archimate:CompositionRelationship" id="a5bb98eb-6c1d-4921-a9c0-98c9aad8aad6" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="17bc30f6-6291-43bc-b2e5-ef5202bc18e4"/>
-    <element xsi:type="archimate:CompositionRelationship" id="e94b7f72-17c2-4873-b380-d13b4d41bac5" source="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac" target="819e7e8c-a185-4b7b-b205-940fefcfe408"/>
     <element xsi:type="archimate:AssociationRelationship" id="89cb6502-27b4-4e3f-9003-025e782532c8" source="819e7e8c-a185-4b7b-b205-940fefcfe408" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
     <element xsi:type="archimate:AssociationRelationship" id="7cc89761-4fb9-4a12-b8a3-a041f3e331cc" source="17bc30f6-6291-43bc-b2e5-ef5202bc18e4" target="0c4b2a85-8b8b-4ae5-ac72-4e0d2e4811ba"/>
     <element xsi:type="archimate:CompositionRelationship" id="e8fa5e21-a7ef-40b0-90cb-01348f4baad2" source="46993d29-c622-4da9-a827-613b19e05632" target="ac982ce3-98bb-468b-a594-1f4463e9babb"/>
@@ -300,81 +307,21 @@
     <element xsi:type="archimate:AccessRelationship" id="313ced4f-857f-4427-b01d-52500abdd37d" source="7c846708-edd4-4a3a-afad-a711b21abeb4" target="b05b5406-553d-4861-9f0d-9dfdce3907fc"/>
     <element xsi:type="archimate:AccessRelationship" id="5343b9e4-3bde-4405-bd5e-c9aee89f9406" source="b7b2aa18-f4d7-4341-945c-03837cb989a6" target="b05b5406-553d-4861-9f0d-9dfdce3907fc" accessType="1"/>
     <element xsi:type="archimate:AggregationRelationship" id="571b3819-03f2-4bc1-83de-20730c99666d" source="108c2382-e2bf-4950-93ba-10e61c915592" target="145becdc-6985-48c4-a520-a423ae80ec59"/>
+    <element xsi:type="archimate:ServingRelationship" id="424515ef-9f7d-470b-a218-c9f833280361" source="a46b13f6-899f-4651-bccd-67685ea0ab9d" target="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e"/>
+    <element xsi:type="archimate:CompositionRelationship" id="d6e5ef8d-2ad7-4441-a8cb-8678d29ff483" source="212f31b8-928f-4714-8aa2-542ecdb81468" target="cfadf0df-e7a6-4465-ba12-5ad6e915a525"/>
+    <element xsi:type="archimate:CompositionRelationship" id="a03a7a78-4128-44ee-82fe-1197dbce4320" source="f3fb9603-2d7a-4264-985f-ad75532816c9" target="70c184e2-dd66-4c98-8a3a-ec23190cff08"/>
+    <element xsi:type="archimate:RealizationRelationship" id="e303b07f-6995-4e45-8000-39ca8a684984" source="f3fb9603-2d7a-4264-985f-ad75532816c9" target="d919bb01-6f6e-4b59-88f1-8764638de3f4"/>
+    <element xsi:type="archimate:AccessRelationship" id="a8e0a53c-91f0-4691-8cab-0b7738e26827" source="727c636e-94a8-4af8-9af6-04bcec1e3143" target="030bea1c-c47c-49f8-89d6-8cd8d8929cf8" accessType="1"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="3e16413b-6f37-48ed-9564-c341b24d42cf" source="9c559689-3063-4980-ba54-6c6571fdfafa" target="6f2885ed-f6ec-421e-ac59-ac6e834612e0"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="b6e9ec44-6ff9-496c-a13b-bae24bce49b7" source="6f2885ed-f6ec-421e-ac59-ac6e834612e0" target="445db22c-cb8a-48ea-81c6-dbc99399fa91"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="b06ba271-aced-4fad-8e9e-4a1460837d4f" source="445db22c-cb8a-48ea-81c6-dbc99399fa91" target="bf0a70a9-46f0-42ae-95ec-ea1656923b9b"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="678a877f-59e8-4922-95b1-894ba143d351" source="bf0a70a9-46f0-42ae-95ec-ea1656923b9b" target="6bc58486-8d4c-49ae-acf9-5113c4688d0a"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="0066e76a-ca90-40ef-bdb0-4651f8ddad94" source="6f2885ed-f6ec-421e-ac59-ac6e834612e0" target="bf0a70a9-46f0-42ae-95ec-ea1656923b9b"/>
+    <element xsi:type="archimate:CompositionRelationship" id="99f55014-b9d5-41ae-8fe4-a0059958bdaa" source="0d63a4ac-c4aa-40ff-8653-14d682a5531f" target="8af6862d-cfee-417d-82d1-d92058948e4a"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="98bda3f4-aebd-4562-947a-b530add99542" source="445db22c-cb8a-48ea-81c6-dbc99399fa91" target="6bc58486-8d4c-49ae-acf9-5113c4688d0a"/>
+    <element xsi:type="archimate:TriggeringRelationship" id="6170adab-7381-4bfb-8bc0-b0e0d66af935" source="6bc58486-8d4c-49ae-acf9-5113c4688d0a" target="8af6862d-cfee-417d-82d1-d92058948e4a"/>
   </folder>
   <folder name="Views" id="6858a5da-9c29-42e4-b91f-7737960e8c81" type="diagrams">
-    <element xsi:type="archimate:ArchimateDiagramModel" name="DC process" id="b2d9e1fa-4c8b-4619-831c-344c1c691750" viewpoint="business_process_cooperation">
-      <child xsi:type="archimate:DiagramObject" id="a8c9c047-2870-4e3d-bb31-d47e6001937e" targetConnections="8920a3e0-9314-48c6-86fa-83af2dcb74ea" archimateElement="fad8e664-4fad-4d4a-9a10-74c710c3b97a">
-        <bounds x="717" y="48" width="120" height="55"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="0c33a8a1-d44d-494a-b128-3846af792c1d" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
-        <bounds x="61" y="203" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="f1abf54e-0289-4202-8ea7-c72315031dcc" source="0c33a8a1-d44d-494a-b128-3846af792c1d" target="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" archimateRelationship="04909a89-4d80-4f31-b9de-3d210fe7ed6c"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" targetConnections="f1abf54e-0289-4202-8ea7-c72315031dcc" archimateElement="0d63a4ac-c4aa-40ff-8653-14d682a5531f">
-        <bounds x="253" y="162" width="1036" height="137"/>
-        <sourceConnection xsi:type="archimate:Connection" id="35584f62-000c-436a-9390-3a6afe5475b1" source="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" target="f58321fb-461a-4b66-8cb0-d45dc732bb9c" archimateRelationship="46975254-c3e9-4883-8aa3-3169ed3d7c29"/>
-        <sourceConnection xsi:type="archimate:Connection" id="8920a3e0-9314-48c6-86fa-83af2dcb74ea" source="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" target="a8c9c047-2870-4e3d-bb31-d47e6001937e" archimateRelationship="743fde0d-4f10-435e-b6ea-04be25793ed4"/>
-        <sourceConnection xsi:type="archimate:Connection" id="ff002975-2b9b-4281-a03c-947fb6b247ee" source="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" target="f6851ebd-cdca-4298-8b94-069d9a770ea4" archimateRelationship="7247a8bd-1ef3-469b-a1ba-f1a7b7b52bb1"/>
-        <sourceConnection xsi:type="archimate:Connection" id="82ec3b58-4528-4a80-add3-7c16c1ac48c7" source="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" target="adcc048e-87bd-4248-b0db-749f59b875ab" archimateRelationship="7e54ed44-7028-4eae-bb37-e4d806adce10"/>
-        <sourceConnection xsi:type="archimate:Connection" id="ce6033ee-3f07-4e5b-9844-f490686e3893" source="3fb66ff0-ade6-40b8-acc6-be518f10aaa4" target="7097cc42-aafc-4a1d-94a6-0f36d5dccefb" archimateRelationship="a9b35bc6-28cd-43e7-8e11-f2a7f7717f59"/>
-        <child xsi:type="archimate:DiagramObject" id="f58321fb-461a-4b66-8cb0-d45dc732bb9c" targetConnections="35584f62-000c-436a-9390-3a6afe5475b1 616c7337-615a-4232-9c0e-253b69af550c" archimateElement="445db22c-cb8a-48ea-81c6-dbc99399fa91">
-          <bounds x="438" y="48" width="163" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="6431677a-a431-4c53-8ff0-8d601599384f" source="f58321fb-461a-4b66-8cb0-d45dc732bb9c" target="6f836328-6a05-4af8-8ac4-d88583b17fc5" archimateRelationship="e90bbf63-7edb-421c-b6c8-2f694dc54642"/>
-          <sourceConnection xsi:type="archimate:Connection" id="d33f983c-0489-4aaa-9492-3bad10f8e706" source="f58321fb-461a-4b66-8cb0-d45dc732bb9c" target="bc498011-2866-4ffb-9c63-93efa1fa47c3" archimateRelationship="ebaeef97-a5a7-4a12-9300-5385ee892937"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="6f836328-6a05-4af8-8ac4-d88583b17fc5" targetConnections="6431677a-a431-4c53-8ff0-8d601599384f" archimateElement="38b61099-7009-443e-b2df-761194403fc9">
-          <bounds x="630" y="68" width="15" height="15"/>
-          <sourceConnection xsi:type="archimate:Connection" id="37d85466-1037-4d76-bee5-ebc33d2d2566" source="6f836328-6a05-4af8-8ac4-d88583b17fc5" target="f6851ebd-cdca-4298-8b94-069d9a770ea4" archimateRelationship="5ce00bed-a816-46ec-852c-8b08ffd09313"/>
-          <sourceConnection xsi:type="archimate:Connection" id="a938843e-c6f7-45b1-8bbe-e3e72dbd2a82" source="6f836328-6a05-4af8-8ac4-d88583b17fc5" target="bfcef93d-60f6-487e-bf92-df52c278dce7" archimateRelationship="ff5a9d5f-d965-4e18-9cff-c0585ea91588">
-            <bendpoint startY="47" endX="-204" endY="47"/>
-            <bendpoint startX="204" startY="46" endY="46"/>
-          </sourceConnection>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="f6851ebd-cdca-4298-8b94-069d9a770ea4" targetConnections="ff002975-2b9b-4281-a03c-947fb6b247ee 37d85466-1037-4d76-bee5-ebc33d2d2566" archimateElement="542c9c45-139b-415b-9888-5dbbb4bb03ff">
-          <bounds x="663" y="48" width="145" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="0de004fb-2718-4139-9f81-1ad7f5e51e59" source="f6851ebd-cdca-4298-8b94-069d9a770ea4" target="bfcef93d-60f6-487e-bf92-df52c278dce7" archimateRelationship="5205c941-97bc-4e24-99a5-6ef8e130b32e"/>
-          <sourceConnection xsi:type="archimate:Connection" id="b4e135a1-4cbc-4346-8d23-a55ca5385bb8" source="f6851ebd-cdca-4298-8b94-069d9a770ea4" target="6a80cbf8-9525-45f4-88a9-e664348af26f" archimateRelationship="61bca2c7-2f9f-4dbc-836c-9161369dd62d"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="bfcef93d-60f6-487e-bf92-df52c278dce7" targetConnections="0de004fb-2718-4139-9f81-1ad7f5e51e59 a938843e-c6f7-45b1-8bbe-e3e72dbd2a82" archimateElement="d4fc0cff-64bd-47c2-be39-0d20e234a2dd">
-          <bounds x="834" y="68" width="15" height="15"/>
-          <sourceConnection xsi:type="archimate:Connection" id="5aae7440-e6c6-4acf-b4cb-6d096deea80c" source="bfcef93d-60f6-487e-bf92-df52c278dce7" target="adcc048e-87bd-4248-b0db-749f59b875ab" archimateRelationship="775b4d4c-00cc-422d-bac0-1cda4fd75754"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="adcc048e-87bd-4248-b0db-749f59b875ab" targetConnections="82ec3b58-4528-4a80-add3-7c16c1ac48c7 5aae7440-e6c6-4acf-b4cb-6d096deea80c" archimateElement="6bc58486-8d4c-49ae-acf9-5113c4688d0a">
-          <bounds x="870" y="48" width="145" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="16e086bb-7aca-4026-9eb0-3907fdd2a160" source="adcc048e-87bd-4248-b0db-749f59b875ab" target="95982d01-b463-4201-b028-693a6aeaf7c3" archimateRelationship="43f0f298-99a7-41e5-b998-5ae8ae89e0ca"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="716c0b59-751e-4cfc-814d-698180ff7c05" archimateElement="5711d3c1-4238-4c90-af05-6238458b576b">
-          <bounds x="24" y="48" width="169" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="409f6278-dea6-49b0-bcde-f28ca241c0ae" source="716c0b59-751e-4cfc-814d-698180ff7c05" target="7097cc42-aafc-4a1d-94a6-0f36d5dccefb" archimateRelationship="77260656-6e53-49a3-ba8b-50950c55b2e9"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="7097cc42-aafc-4a1d-94a6-0f36d5dccefb" targetConnections="ce6033ee-3f07-4e5b-9844-f490686e3893 409f6278-dea6-49b0-bcde-f28ca241c0ae" archimateElement="9c559689-3063-4980-ba54-6c6571fdfafa">
-          <bounds x="264" y="48" width="120" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="616c7337-615a-4232-9c0e-253b69af550c" source="7097cc42-aafc-4a1d-94a6-0f36d5dccefb" target="f58321fb-461a-4b66-8cb0-d45dc732bb9c" archimateRelationship="85a1d04f-8d78-45c3-96af-7eb8da2de5bb"/>
-          <sourceConnection xsi:type="archimate:Connection" id="ee4dada7-3241-48d4-a119-bd05a72e51f7" source="7097cc42-aafc-4a1d-94a6-0f36d5dccefb" target="7d082516-21c5-4c88-ac21-31203e5cb42c" archimateRelationship="d5e09a47-9af8-40b6-b997-b8d222fbd40c"/>
-        </child>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="bc498011-2866-4ffb-9c63-93efa1fa47c3" targetConnections="d33f983c-0489-4aaa-9492-3bad10f8e706 ab2bca2f-4ae6-45f6-b307-763edad1e90c" archimateElement="53ac573b-bada-4a1a-8eb5-debaa24d3809">
-        <bounds x="717" y="340" width="120" height="55"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="6a80cbf8-9525-45f4-88a9-e664348af26f" targetConnections="b4e135a1-4cbc-4346-8d23-a55ca5385bb8 75c7f933-7f06-4363-af75-98440d25c502" archimateElement="95d4f54d-d61a-494e-9ae7-f04687e1e0f7">
-        <bounds x="933" y="340" width="120" height="55"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="7d082516-21c5-4c88-ac21-31203e5cb42c" targetConnections="ee4dada7-3241-48d4-a119-bd05a72e51f7 09ef7818-9242-4f80-a96f-3bc444fbf641" archimateElement="030bea1c-c47c-49f8-89d6-8cd8d8929cf8">
-        <bounds x="517" y="340" width="120" height="55"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="95982d01-b463-4201-b028-693a6aeaf7c3" targetConnections="16e086bb-7aca-4026-9eb0-3907fdd2a160" archimateElement="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508">
-        <bounds x="1141" y="340" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="75c7f933-7f06-4363-af75-98440d25c502" source="95982d01-b463-4201-b028-693a6aeaf7c3" target="6a80cbf8-9525-45f4-88a9-e664348af26f" archimateRelationship="c576ed23-6c2d-41e8-9c2b-b70f55934df1"/>
-        <sourceConnection xsi:type="archimate:Connection" id="ab2bca2f-4ae6-45f6-b307-763edad1e90c" source="95982d01-b463-4201-b028-693a6aeaf7c3" target="bc498011-2866-4ffb-9c63-93efa1fa47c3" archimateRelationship="259a3bae-99c7-4af9-8754-aa31175d39db">
-          <bendpoint startX="-46" startY="53" endX="378" endY="53"/>
-          <bendpoint startX="-388" startY="50" endX="36" endY="50"/>
-        </sourceConnection>
-        <sourceConnection xsi:type="archimate:Connection" id="09ef7818-9242-4f80-a96f-3bc444fbf641" source="95982d01-b463-4201-b028-693a6aeaf7c3" target="7d082516-21c5-4c88-ac21-31203e5cb42c" archimateRelationship="72639f88-abea-4c10-bbbe-f33e1209959c">
-          <bendpoint startX="-29" startY="64" endX="595" endY="64"/>
-          <bendpoint startX="-586" startY="61" endX="38" endY="61"/>
-        </sourceConnection>
-      </child>
-    </element>
     <element xsi:type="archimate:ArchimateDiagramModel" name="Using eDelivery for information exchange" id="a8345071-4aee-4bf1-bb65-64a973ab97ad" viewpoint="business_process_cooperation">
       <child xsi:type="archimate:DiagramObject" id="185d2b7a-83f3-473d-b3bf-a6f15fde82d3" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
         <bounds x="98" y="235" width="120" height="55"/>
@@ -493,94 +440,9 @@
         <bounds x="613" y="418" width="120" height="55"/>
       </child>
     </element>
-    <element xsi:type="archimate:ArchimateDiagramModel" name="Complete process between DC and DP (vertical)" id="5524a28e-6215-4397-b607-ad6437677c9d" viewpoint="business_process_cooperation">
-      <child xsi:type="archimate:DiagramObject" id="3a01ed09-0aa0-428f-9e3d-91a524f425df" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
-        <bounds x="312" y="120" width="183" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="7d9faf8c-e68a-46ad-a703-2b742f1da061" source="3a01ed09-0aa0-428f-9e3d-91a524f425df" target="bd03eb18-6582-4620-ae0b-caef394f18b0" archimateRelationship="04909a89-4d80-4f31-b9de-3d210fe7ed6c"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="aed2e0a1-ee98-47bd-a48f-203f0fcf3c84" archimateElement="8a97d09b-a4db-47f1-bf36-d3dc84e0f234">
-        <bounds x="851" y="120" width="181" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="1f8a6507-6a55-49ab-b7d0-9aa8f6e6250b" source="aed2e0a1-ee98-47bd-a48f-203f0fcf3c84" target="6308026a-b919-481c-bb9b-092eab5a3f01" archimateRelationship="7226f430-eda2-4e1e-bf19-3a9117613bb5"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="bd03eb18-6582-4620-ae0b-caef394f18b0" targetConnections="7d9faf8c-e68a-46ad-a703-2b742f1da061" archimateElement="0d63a4ac-c4aa-40ff-8653-14d682a5531f">
-        <bounds x="312" y="200" width="183" height="569"/>
-        <sourceConnection xsi:type="archimate:Connection" id="ea3aa038-afaa-40b3-aa1d-61c7c6f40222" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="d88bba15-37e1-4572-9b91-8cea4d110af2" archimateRelationship="743fde0d-4f10-435e-b6ea-04be25793ed4"/>
-        <sourceConnection xsi:type="archimate:Connection" id="eb3875bb-4a9e-4e02-b76a-1e3fe0b9ccc6" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="75212b3e-0299-4e45-a8b1-0edc41c8266e" archimateRelationship="7e54ed44-7028-4eae-bb37-e4d806adce10"/>
-        <sourceConnection xsi:type="archimate:Connection" id="ac9d6cb3-78d7-4786-a94d-085bab079ed0" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="734ddcf5-7cb1-4f6f-a2b6-f1536118d586" archimateRelationship="1b62e40b-6cce-4920-b99c-cb53245bebc6"/>
-        <sourceConnection xsi:type="archimate:Connection" id="555e930f-4a89-46fe-a553-e8b47cacff7c" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="89bb1927-54a9-47cf-9ed1-ca54fdf60ee3" archimateRelationship="a9b35bc6-28cd-43e7-8e11-f2a7f7717f59"/>
-        <sourceConnection xsi:type="archimate:Connection" id="484d41ae-8fcb-4d5d-95ca-a2fe93d829ed" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="b974fe82-d084-4f1b-98e2-eec06a0ab2eb" archimateRelationship="46975254-c3e9-4883-8aa3-3169ed3d7c29"/>
-        <sourceConnection xsi:type="archimate:Connection" id="efa1c3c6-a408-4ba0-8548-ffdb97edba4d" source="bd03eb18-6582-4620-ae0b-caef394f18b0" target="34b44261-6050-4b81-9ced-78bdb1a5d0ec" archimateRelationship="7247a8bd-1ef3-469b-a1ba-f1a7b7b52bb1"/>
-        <child xsi:type="archimate:DiagramObject" id="75212b3e-0299-4e45-a8b1-0edc41c8266e" targetConnections="eb3875bb-4a9e-4e02-b76a-1e3fe0b9ccc6 2cada7fe-7a14-43e5-acf1-7f90eabb6cf6" archimateElement="6bc58486-8d4c-49ae-acf9-5113c4688d0a">
-          <bounds x="33" y="347" width="120" height="69"/>
-          <sourceConnection xsi:type="archimate:Connection" id="39377a93-cc2e-4649-8ee0-9bb6600fe8ca" source="75212b3e-0299-4e45-a8b1-0edc41c8266e" target="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" archimateRelationship="43f0f298-99a7-41e5-b998-5ae8ae89e0ca"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="c8325022-38d5-4ddb-838a-adb685fae637" archimateElement="5711d3c1-4238-4c90-af05-6238458b576b">
-          <bounds x="33" y="32" width="120" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="8b11c7bb-6705-4ef3-8f0a-70578bbc2b6e" source="c8325022-38d5-4ddb-838a-adb685fae637" target="89bb1927-54a9-47cf-9ed1-ca54fdf60ee3" archimateRelationship="77260656-6e53-49a3-ba8b-50950c55b2e9"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="89bb1927-54a9-47cf-9ed1-ca54fdf60ee3" targetConnections="555e930f-4a89-46fe-a553-e8b47cacff7c 8b11c7bb-6705-4ef3-8f0a-70578bbc2b6e" archimateElement="9c559689-3063-4980-ba54-6c6571fdfafa">
-          <bounds x="33" y="120" width="120" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="ab001448-8009-4983-b3a3-4d010ad9a5d4" source="89bb1927-54a9-47cf-9ed1-ca54fdf60ee3" target="1cb1894c-21aa-4696-b983-f05ddcc9d7c9" archimateRelationship="d5e09a47-9af8-40b6-b997-b8d222fbd40c"/>
-          <sourceConnection xsi:type="archimate:Connection" id="f8a2a98b-cd51-4d29-a824-9c9e04d74b2d" source="89bb1927-54a9-47cf-9ed1-ca54fdf60ee3" target="b974fe82-d084-4f1b-98e2-eec06a0ab2eb" archimateRelationship="85a1d04f-8d78-45c3-96af-7eb8da2de5bb"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="b974fe82-d084-4f1b-98e2-eec06a0ab2eb" targetConnections="484d41ae-8fcb-4d5d-95ca-a2fe93d829ed f8a2a98b-cd51-4d29-a824-9c9e04d74b2d" archimateElement="445db22c-cb8a-48ea-81c6-dbc99399fa91">
-          <bounds x="33" y="194" width="120" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="00c6d7b1-a89f-4059-a2e4-4944765f3d06" source="b974fe82-d084-4f1b-98e2-eec06a0ab2eb" target="ad4510ee-c8c0-483f-9a23-3405f1f24c68" archimateRelationship="ebaeef97-a5a7-4a12-9300-5385ee892937"/>
-          <sourceConnection xsi:type="archimate:Connection" id="0672b06a-6e8b-47b5-afef-430e1ab4eb9a" source="b974fe82-d084-4f1b-98e2-eec06a0ab2eb" target="34b44261-6050-4b81-9ced-78bdb1a5d0ec" archimateRelationship="3c4793d1-7323-442f-82b1-b8df2d720110"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="34b44261-6050-4b81-9ced-78bdb1a5d0ec" targetConnections="efa1c3c6-a408-4ba0-8548-ffdb97edba4d 0672b06a-6e8b-47b5-afef-430e1ab4eb9a" archimateElement="542c9c45-139b-415b-9888-5dbbb4bb03ff">
-          <bounds x="33" y="269" width="120" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="64b8476e-ebce-4b0d-8917-d1aab3ea7f43" source="34b44261-6050-4b81-9ced-78bdb1a5d0ec" target="0686b730-66fc-4264-8f8e-d7fef064cc28" archimateRelationship="61bca2c7-2f9f-4dbc-836c-9161369dd62d"/>
-          <sourceConnection xsi:type="archimate:Connection" id="2cada7fe-7a14-43e5-acf1-7f90eabb6cf6" source="34b44261-6050-4b81-9ced-78bdb1a5d0ec" target="75212b3e-0299-4e45-a8b1-0edc41c8266e" archimateRelationship="1a6c5e38-43e7-421d-8b88-000ad22bea39"/>
-        </child>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="d88bba15-37e1-4572-9b91-8cea4d110af2" targetConnections="ea3aa038-afaa-40b3-aa1d-61c7c6f40222" archimateElement="fad8e664-4fad-4d4a-9a10-74c710c3b97a">
-        <bounds x="142" y="200" width="120" height="55"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" targetConnections="39377a93-cc2e-4649-8ee0-9bb6600fe8ca 66bf98d7-bab5-4bc2-ad8e-791eddf1c57c" archimateElement="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508">
-        <bounds x="613" y="554" width="120" height="55"/>
-        <sourceConnection xsi:type="archimate:Connection" id="55f42732-70ab-4067-8ac3-7a507b4f28d5" source="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" target="1cb1894c-21aa-4696-b983-f05ddcc9d7c9" archimateRelationship="72639f88-abea-4c10-bbbe-f33e1209959c">
-          <bendpoint startX="-106" startY="-54" endY="193"/>
-          <bendpoint startX="-106" startY="-125" endY="122"/>
-        </sourceConnection>
-        <sourceConnection xsi:type="archimate:Connection" id="d868be14-bd34-4fa1-93ea-f6fdc296ff41" source="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" target="0686b730-66fc-4264-8f8e-d7fef064cc28" archimateRelationship="c576ed23-6c2d-41e8-9c2b-b70f55934df1"/>
-        <sourceConnection xsi:type="archimate:Connection" id="36a7e9d6-53eb-4aa1-b48d-28cfa3cf3466" source="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" target="ad4510ee-c8c0-483f-9a23-3405f1f24c68" archimateRelationship="259a3bae-99c7-4af9-8754-aa31175d39db"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="6308026a-b919-481c-bb9b-092eab5a3f01" targetConnections="1f8a6507-6a55-49ab-b7d0-9aa8f6e6250b" archimateElement="a2307ac8-440f-4e9d-94ec-310d20b36df8">
-        <bounds x="851" y="200" width="181" height="569"/>
-        <sourceConnection xsi:type="archimate:Connection" id="a9e2f15f-5224-40e4-8812-23247a298c99" source="6308026a-b919-481c-bb9b-092eab5a3f01" target="ef95e097-8130-46df-9a05-7da4ba5ea6c1" archimateRelationship="bc0c881b-2587-4c7d-820f-99ab59a701b4"/>
-        <sourceConnection xsi:type="archimate:Connection" id="cd4beb20-0e10-4ad8-ae9a-3f8b6d00d865" source="6308026a-b919-481c-bb9b-092eab5a3f01" target="da7b2934-576f-4655-9163-281ebc85f711" archimateRelationship="9d9dca79-9456-48e7-99b0-e6401a71d55d"/>
-        <sourceConnection xsi:type="archimate:Connection" id="8aa63e9d-c9b6-4694-911a-7a7fb5448451" source="6308026a-b919-481c-bb9b-092eab5a3f01" target="d09d9132-d1c0-4907-8489-3ec119a85f34" archimateRelationship="8f45d271-86d5-4609-95cc-008e96b631e0"/>
-        <sourceConnection xsi:type="archimate:Connection" id="66bf98d7-bab5-4bc2-ad8e-791eddf1c57c" source="6308026a-b919-481c-bb9b-092eab5a3f01" target="8bcf5875-4f91-4f0a-8827-e3b786c0ebe6" archimateRelationship="4646b9a5-e538-4964-87b4-ff32fa20fa01"/>
-        <child xsi:type="archimate:DiagramObject" id="ef95e097-8130-46df-9a05-7da4ba5ea6c1" targetConnections="a9e2f15f-5224-40e4-8812-23247a298c99" archimateElement="52a66463-82a1-4de1-8405-57da30cbfd3b">
-          <bounds x="35" y="352" width="120" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="d8745083-f16e-4ca2-a3a9-d79abf52de9e" source="ef95e097-8130-46df-9a05-7da4ba5ea6c1" target="d09d9132-d1c0-4907-8489-3ec119a85f34" archimateRelationship="7f81d755-9b4d-4232-8557-3cefe31f5e0d"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="da7b2934-576f-4655-9163-281ebc85f711" targetConnections="cd4beb20-0e10-4ad8-ae9a-3f8b6d00d865 a1b7fdca-e2a1-47a1-a4a1-fa81df5eedda" archimateElement="c89398a3-0a96-4369-a8c0-b7fbbccf232c">
-          <bounds x="35" y="505" width="120" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="4b8b8458-24e3-4d64-833b-3580dd2da83a" source="da7b2934-576f-4655-9163-281ebc85f711" target="734ddcf5-7cb1-4f6f-a2b6-f1536118d586" archimateRelationship="e0ac69dc-fcd3-4ec6-9f11-14490b4acf63"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="d09d9132-d1c0-4907-8489-3ec119a85f34" targetConnections="8aa63e9d-c9b6-4694-911a-7a7fb5448451 d8745083-f16e-4ca2-a3a9-d79abf52de9e" archimateElement="727c636e-94a8-4af8-9af6-04bcec1e3143">
-          <bounds x="35" y="428" width="120" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="a1b7fdca-e2a1-47a1-a4a1-fa81df5eedda" source="d09d9132-d1c0-4907-8489-3ec119a85f34" target="da7b2934-576f-4655-9163-281ebc85f711" archimateRelationship="c00dabfa-1e04-4dd3-b160-d62a1bbf9237"/>
-        </child>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="1cb1894c-21aa-4696-b983-f05ddcc9d7c9" targetConnections="55f42732-70ab-4067-8ac3-7a507b4f28d5 ab001448-8009-4983-b3a3-4d010ad9a5d4" archimateElement="030bea1c-c47c-49f8-89d6-8cd8d8929cf8">
-        <bounds x="520" y="326" width="94" height="44"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="0686b730-66fc-4264-8f8e-d7fef064cc28" targetConnections="d868be14-bd34-4fa1-93ea-f6fdc296ff41 64b8476e-ebce-4b0d-8917-d1aab3ea7f43" archimateElement="95d4f54d-d61a-494e-9ae7-f04687e1e0f7">
-        <bounds x="732" y="472" width="94" height="44"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="ad4510ee-c8c0-483f-9a23-3405f1f24c68" targetConnections="36a7e9d6-53eb-4aa1-b48d-28cfa3cf3466 00c6d7b1-a89f-4059-a2e4-4944765f3d06" archimateElement="53ac573b-bada-4a1a-8eb5-debaa24d3809">
-        <bounds x="626" y="402" width="94" height="44"/>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="734ddcf5-7cb1-4f6f-a2b6-f1536118d586" targetConnections="ac9d6cb3-78d7-4786-a94d-085bab079ed0 4b8b8458-24e3-4d64-833b-3580dd2da83a" archimateElement="1b0685dc-27ec-49a5-8dad-448356ff10ef">
-        <bounds x="613" y="705" width="120" height="55"/>
-      </child>
-    </element>
-    <element xsi:type="archimate:ArchimateDiagramModel" name="Complete process between DC and DP (horizontal)" id="15f55112-e64e-4680-a0f6-2696a20eaf0a" viewpoint="business_process_cooperation">
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Complete process between DC and DP" id="15f55112-e64e-4680-a0f6-2696a20eaf0a" viewpoint="business_process_cooperation">
       <child xsi:type="archimate:DiagramObject" id="7f2cdae5-bff1-4066-bc0a-c782b12157de" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
-        <bounds x="79" y="192" width="183" height="55"/>
+        <bounds x="79" y="237" width="183" height="55"/>
         <sourceConnection xsi:type="archimate:Connection" id="19ba4494-c7d3-4729-9362-031587780cce" source="7f2cdae5-bff1-4066-bc0a-c782b12157de" target="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" archimateRelationship="04909a89-4d80-4f31-b9de-3d210fe7ed6c"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="c8bfbe15-fc95-4f35-80c6-59b99ba59bfd" archimateElement="8a97d09b-a4db-47f1-bf36-d3dc84e0f234">
@@ -588,16 +450,17 @@
         <sourceConnection xsi:type="archimate:Connection" id="af394d1d-d551-4231-b74d-07b8dfcd3954" source="c8bfbe15-fc95-4f35-80c6-59b99ba59bfd" target="702d5f62-6ead-4612-ab4c-159cf1ace010" archimateRelationship="7226f430-eda2-4e1e-bf19-3a9117613bb5"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" targetConnections="19ba4494-c7d3-4729-9362-031587780cce" archimateElement="0d63a4ac-c4aa-40ff-8653-14d682a5531f">
-        <bounds x="318" y="174" width="962" height="179"/>
+        <bounds x="318" y="174" width="895" height="179"/>
         <sourceConnection xsi:type="archimate:Connection" id="6e0d849b-6f8d-42a7-a121-15a2d8dc14ee" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="4b423323-d871-466c-9ccb-10d0bd5aad29" archimateRelationship="743fde0d-4f10-435e-b6ea-04be25793ed4"/>
         <sourceConnection xsi:type="archimate:Connection" id="a6ea6fa4-57da-4e8b-989b-bf8148dda12c" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="aa91b9ac-8844-4a7a-8683-c46c32c49e10" archimateRelationship="7e54ed44-7028-4eae-bb37-e4d806adce10"/>
         <sourceConnection xsi:type="archimate:Connection" id="e5b451b4-0361-4053-8fd0-4ff56007a572" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="eb8fcc2e-c4c6-4ea2-9efc-ffc4dc7c1ab5" archimateRelationship="1b62e40b-6cce-4920-b99c-cb53245bebc6"/>
         <sourceConnection xsi:type="archimate:Connection" id="0f11d79b-aae6-4999-bab4-13c4cc60ce5c" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="2f0b3a80-f2c2-4f61-ac70-d1a42bc7f21e" archimateRelationship="a9b35bc6-28cd-43e7-8e11-f2a7f7717f59"/>
         <sourceConnection xsi:type="archimate:Connection" id="6b5a8ece-3435-45d3-9ee7-d4fbb96948ee" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="85c47833-52a2-45cd-a517-cf28b62d20d8" archimateRelationship="46975254-c3e9-4883-8aa3-3169ed3d7c29"/>
-        <sourceConnection xsi:type="archimate:Connection" id="38c76484-ab24-4ae2-a4c6-174ca0799695" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="c3bce02f-1811-48b2-840c-1f3ce72521fc" archimateRelationship="7247a8bd-1ef3-469b-a1ba-f1a7b7b52bb1"/>
-        <child xsi:type="archimate:DiagramObject" id="aa91b9ac-8844-4a7a-8683-c46c32c49e10" targetConnections="a6ea6fa4-57da-4e8b-989b-bf8148dda12c bebfbeb0-3405-4bab-82b3-4309b7f4f026" archimateElement="6bc58486-8d4c-49ae-acf9-5113c4688d0a">
-          <bounds x="659" y="32" width="156" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="01d08e04-a1ef-4eaf-8f05-8994b593be51" source="8645fd80-b3ff-4f15-bf3c-5b48776d3c50" target="37230566-4e7a-4986-a853-ee106502d14a" archimateRelationship="99f55014-b9d5-41ae-8fe4-a0059958bdaa"/>
+        <child xsi:type="archimate:DiagramObject" id="aa91b9ac-8844-4a7a-8683-c46c32c49e10" targetConnections="a6ea6fa4-57da-4e8b-989b-bf8148dda12c b8788d04-e0b6-4c25-8724-461de9ec170b" archimateElement="6bc58486-8d4c-49ae-acf9-5113c4688d0a">
+          <bounds x="529" y="32" width="156" height="55"/>
           <sourceConnection xsi:type="archimate:Connection" id="788f2cf3-aad3-4bc3-8245-bc0037e442da" source="aa91b9ac-8844-4a7a-8683-c46c32c49e10" target="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" archimateRelationship="43f0f298-99a7-41e5-b998-5ae8ae89e0ca"/>
+          <sourceConnection xsi:type="archimate:Connection" id="4bdb329c-2afa-4449-bc56-fa077d71289e" source="aa91b9ac-8844-4a7a-8683-c46c32c49e10" target="37230566-4e7a-4986-a853-ee106502d14a" archimateRelationship="6170adab-7381-4bfb-8bc0-b0e0d66af935"/>
         </child>
         <child xsi:type="archimate:DiagramObject" id="57579fb1-2154-47b6-844c-c38e68725177" archimateElement="5711d3c1-4238-4c90-af05-6238458b576b">
           <bounds x="33" y="32" width="120" height="55"/>
@@ -609,60 +472,58 @@
           <sourceConnection xsi:type="archimate:Connection" id="e99d3006-1d19-409c-a738-8c7a3917bf26" source="2f0b3a80-f2c2-4f61-ac70-d1a42bc7f21e" target="85c47833-52a2-45cd-a517-cf28b62d20d8" archimateRelationship="85a1d04f-8d78-45c3-96af-7eb8da2de5bb"/>
         </child>
         <child xsi:type="archimate:DiagramObject" id="85c47833-52a2-45cd-a517-cf28b62d20d8" targetConnections="6b5a8ece-3435-45d3-9ee7-d4fbb96948ee e99d3006-1d19-409c-a738-8c7a3917bf26" archimateElement="445db22c-cb8a-48ea-81c6-dbc99399fa91">
-          <bounds x="348" y="32" width="120" height="55"/>
+          <bounds x="348" y="32" width="146" height="55"/>
           <sourceConnection xsi:type="archimate:Connection" id="a7e58d3d-de2a-464b-8290-420389de9925" source="85c47833-52a2-45cd-a517-cf28b62d20d8" target="75bb5413-c260-43f1-9735-90fd46f2ba78" archimateRelationship="ebaeef97-a5a7-4a12-9300-5385ee892937"/>
-          <sourceConnection xsi:type="archimate:Connection" id="7bb54f81-fe19-4a2f-956a-cf4d7d0307b9" source="85c47833-52a2-45cd-a517-cf28b62d20d8" target="c3bce02f-1811-48b2-840c-1f3ce72521fc" archimateRelationship="3c4793d1-7323-442f-82b1-b8df2d720110"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b8788d04-e0b6-4c25-8724-461de9ec170b" source="85c47833-52a2-45cd-a517-cf28b62d20d8" target="aa91b9ac-8844-4a7a-8683-c46c32c49e10" archimateRelationship="98bda3f4-aebd-4562-947a-b530add99542"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="c3bce02f-1811-48b2-840c-1f3ce72521fc" targetConnections="38c76484-ab24-4ae2-a4c6-174ca0799695 7bb54f81-fe19-4a2f-956a-cf4d7d0307b9" archimateElement="542c9c45-139b-415b-9888-5dbbb4bb03ff">
-          <bounds x="501" y="32" width="120" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="f784f3b4-dbc5-480d-a92b-07b13624d061" source="c3bce02f-1811-48b2-840c-1f3ce72521fc" target="7f4a81a1-d4d5-4a7d-93c2-92e36b4b9187" archimateRelationship="61bca2c7-2f9f-4dbc-836c-9161369dd62d"/>
-          <sourceConnection xsi:type="archimate:Connection" id="bebfbeb0-3405-4bab-82b3-4309b7f4f026" source="c3bce02f-1811-48b2-840c-1f3ce72521fc" target="aa91b9ac-8844-4a7a-8683-c46c32c49e10" archimateRelationship="1a6c5e38-43e7-421d-8b88-000ad22bea39"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="79da122f-e446-49e4-bcc4-2b3872153db5" targetConnections="d51be25a-db87-4045-bc1f-44f70588796b 0b8381bc-5729-4555-841a-e40ebac436e1" archimateElement="030bea1c-c47c-49f8-89d6-8cd8d8929cf8">
-          <bounds x="206" y="123" width="94" height="44"/>
+        <child xsi:type="archimate:DiagramObject" id="79da122f-e446-49e4-bcc4-2b3872153db5" targetConnections="d51be25a-db87-4045-bc1f-44f70588796b 0b8381bc-5729-4555-841a-e40ebac436e1 f3a11cf8-98a3-4e92-b0d8-6ea4e111c3d3" archimateElement="030bea1c-c47c-49f8-89d6-8cd8d8929cf8">
+          <bounds x="193" y="120" width="120" height="44"/>
         </child>
         <child xsi:type="archimate:DiagramObject" id="75bb5413-c260-43f1-9735-90fd46f2ba78" targetConnections="a7e58d3d-de2a-464b-8290-420389de9925 ffe20d3a-11ea-4ed6-aab0-c9bb9e990453" archimateElement="53ac573b-bada-4a1a-8eb5-debaa24d3809">
-          <bounds x="361" y="123" width="94" height="44"/>
+          <bounds x="348" y="120" width="146" height="44"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="7f4a81a1-d4d5-4a7d-93c2-92e36b4b9187" targetConnections="f784f3b4-dbc5-480d-a92b-07b13624d061 85bd79ac-4d34-43fc-b95e-a2e0a44ed583" archimateElement="95d4f54d-d61a-494e-9ae7-f04687e1e0f7">
-          <bounds x="514" y="123" width="94" height="44"/>
+        <child xsi:type="archimate:DiagramObject" id="37230566-4e7a-4986-a853-ee106502d14a" targetConnections="01d08e04-a1ef-4eaf-8f05-8994b593be51 4bdb329c-2afa-4449-bc56-fa077d71289e" archimateElement="8af6862d-cfee-417d-82d1-d92058948e4a">
+          <bounds x="732" y="36" width="129" height="55"/>
         </child>
       </child>
       <child xsi:type="archimate:DiagramObject" id="4b423323-d871-466c-9ccb-10d0bd5aad29" targetConnections="6e0d849b-6f8d-42a7-a121-15a2d8dc14ee" archimateElement="fad8e664-4fad-4d4a-9a10-74c710c3b97a">
         <bounds x="344" y="81" width="120" height="55"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="702d5f62-6ead-4612-ab4c-159cf1ace010" targetConnections="af394d1d-d551-4231-b74d-07b8dfcd3954" archimateElement="a2307ac8-440f-4e9d-94ec-310d20b36df8">
-        <bounds x="318" y="481" width="962" height="130"/>
+        <bounds x="318" y="481" width="895" height="119"/>
         <sourceConnection xsi:type="archimate:Connection" id="2b9d9f62-f8ad-407b-b6f4-46487dc8fdef" source="702d5f62-6ead-4612-ab4c-159cf1ace010" target="2c9376d3-71cc-42f0-922d-25744c5a9545" archimateRelationship="bc0c881b-2587-4c7d-820f-99ab59a701b4"/>
         <sourceConnection xsi:type="archimate:Connection" id="8326543d-d50b-41b7-9533-1a33be08feb7" source="702d5f62-6ead-4612-ab4c-159cf1ace010" target="7b383d01-f8b8-4e4e-a730-54e7b5c88b85" archimateRelationship="9d9dca79-9456-48e7-99b0-e6401a71d55d"/>
         <sourceConnection xsi:type="archimate:Connection" id="2b2277e4-87fe-42d7-b1b3-5f8ebed59738" source="702d5f62-6ead-4612-ab4c-159cf1ace010" target="2b28c958-6f3b-43e2-8c45-28fa0da43c6e" archimateRelationship="8f45d271-86d5-4609-95cc-008e96b631e0"/>
         <sourceConnection xsi:type="archimate:Connection" id="dc3162a3-6003-4204-ad10-ef1d4305d36c" source="702d5f62-6ead-4612-ab4c-159cf1ace010" target="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" archimateRelationship="4646b9a5-e538-4964-87b4-ff32fa20fa01"/>
         <child xsi:type="archimate:DiagramObject" id="2c9376d3-71cc-42f0-922d-25744c5a9545" targetConnections="2b9d9f62-f8ad-407b-b6f4-46487dc8fdef" archimateElement="52a66463-82a1-4de1-8405-57da30cbfd3b">
-          <bounds x="489" y="43" width="120" height="55"/>
+          <bounds x="409" y="42" width="120" height="55"/>
           <sourceConnection xsi:type="archimate:Connection" id="b27e4411-41af-46f8-9609-2d49b5ba3c75" source="2c9376d3-71cc-42f0-922d-25744c5a9545" target="2b28c958-6f3b-43e2-8c45-28fa0da43c6e" archimateRelationship="7f81d755-9b4d-4232-8557-3cefe31f5e0d"/>
         </child>
         <child xsi:type="archimate:DiagramObject" id="7b383d01-f8b8-4e4e-a730-54e7b5c88b85" targetConnections="8326543d-d50b-41b7-9533-1a33be08feb7 b17b4724-23e5-4a8a-8fa2-53ea871d89de" archimateElement="c89398a3-0a96-4369-a8c0-b7fbbccf232c">
-          <bounds x="823" y="43" width="126" height="55"/>
-          <sourceConnection xsi:type="archimate:Connection" id="45d9fbed-c157-46bf-b696-61c77afc341c" source="7b383d01-f8b8-4e4e-a730-54e7b5c88b85" target="eb8fcc2e-c4c6-4ea2-9efc-ffc4dc7c1ab5" archimateRelationship="e0ac69dc-fcd3-4ec6-9f11-14490b4acf63"/>
+          <bounds x="729" y="41" width="126" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="45d9fbed-c157-46bf-b696-61c77afc341c" source="7b383d01-f8b8-4e4e-a730-54e7b5c88b85" target="eb8fcc2e-c4c6-4ea2-9efc-ffc4dc7c1ab5" archimateRelationship="e0ac69dc-fcd3-4ec6-9f11-14490b4acf63">
+            <bendpoint startX="6" startY="-70" endY="66"/>
+          </sourceConnection>
         </child>
         <child xsi:type="archimate:DiagramObject" id="2b28c958-6f3b-43e2-8c45-28fa0da43c6e" targetConnections="2b2277e4-87fe-42d7-b1b3-5f8ebed59738 b27e4411-41af-46f8-9609-2d49b5ba3c75" archimateElement="727c636e-94a8-4af8-9af6-04bcec1e3143">
-          <bounds x="661" y="43" width="120" height="55"/>
+          <bounds x="571" y="43" width="120" height="55"/>
           <sourceConnection xsi:type="archimate:Connection" id="b17b4724-23e5-4a8a-8fa2-53ea871d89de" source="2b28c958-6f3b-43e2-8c45-28fa0da43c6e" target="7b383d01-f8b8-4e4e-a730-54e7b5c88b85" archimateRelationship="c00dabfa-1e04-4dd3-b160-d62a1bbf9237"/>
+          <sourceConnection xsi:type="archimate:Connection" id="f3a11cf8-98a3-4e92-b0d8-6ea4e111c3d3" source="2b28c958-6f3b-43e2-8c45-28fa0da43c6e" target="79da122f-e446-49e4-bcc4-2b3872153db5" archimateRelationship="a8e0a53c-91f0-4691-8cab-0b7738e26827">
+            <bendpoint startX="-1" startY="-95" endX="377" endY="137"/>
+            <bendpoint startX="-385" startY="-95" endX="-7" endY="137"/>
+          </sourceConnection>
         </child>
       </child>
       <child xsi:type="archimate:DiagramObject" id="eb8fcc2e-c4c6-4ea2-9efc-ffc4dc7c1ab5" targetConnections="e5b451b4-0361-4053-8fd0-4ff56007a572 45d9fbed-c157-46bf-b696-61c77afc341c" archimateElement="1b0685dc-27ec-49a5-8dad-448356ff10ef">
-        <bounds x="1143" y="387" width="120" height="55"/>
+        <bounds x="1044" y="386" width="145" height="55"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" targetConnections="788f2cf3-aad3-4bc3-8245-bc0037e442da dc3162a3-6003-4204-ad10-ef1d4305d36c" archimateElement="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508">
-        <bounds x="984" y="387" width="120" height="55"/>
+        <bounds x="852" y="386" width="145" height="55"/>
         <sourceConnection xsi:type="archimate:Connection" id="0b8381bc-5729-4555-841a-e40ebac436e1" source="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" target="79da122f-e446-49e4-bcc4-2b3872153db5" archimateRelationship="72639f88-abea-4c10-bbbe-f33e1209959c">
-          <bendpoint startX="-453" startY="12" endX="26" endY="107"/>
-        </sourceConnection>
-        <sourceConnection xsi:type="archimate:Connection" id="85bd79ac-4d34-43fc-b95e-a2e0a44ed583" source="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" target="7f4a81a1-d4d5-4a7d-93c2-92e36b4b9187" archimateRelationship="c576ed23-6c2d-41e8-9c2b-b70f55934df1">
-          <bendpoint startX="-136" startY="-17" endX="35" endY="78"/>
+          <bendpoint startX="-336" startY="9" endX="17" endY="92"/>
         </sourceConnection>
         <sourceConnection xsi:type="archimate:Connection" id="ffe20d3a-11ea-4ed6-aab0-c9bb9e990453" source="ca8ed5a4-f312-4d3e-9b0a-e47407004e63" target="75bb5413-c260-43f1-9735-90fd46f2ba78" archimateRelationship="259a3bae-99c7-4af9-8754-aa31175d39db">
-          <bendpoint startX="-296" startY="-2" endX="28" endY="93"/>
+          <bendpoint startX="-192" startY="-3" endX="-7" endY="80"/>
         </sourceConnection>
       </child>
     </element>
@@ -807,19 +668,14 @@
       </child>
       <child xsi:type="archimate:DiagramObject" id="d212203a-2da1-48e0-b47b-ca409f18654d" archimateElement="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac">
         <bounds x="1452" y="24" width="636" height="396"/>
-        <sourceConnection xsi:type="archimate:Connection" id="37ebc24a-d2bd-4689-ae86-e00361e4ae19" source="d212203a-2da1-48e0-b47b-ca409f18654d" target="420bc620-3fde-4bcf-bee7-6aa87c775412" archimateRelationship="17b2804b-bcb2-400f-b93c-827ca8523d9e"/>
-        <sourceConnection xsi:type="archimate:Connection" id="2ae5d749-e8ff-4c19-b580-3d399db3d47c" source="d212203a-2da1-48e0-b47b-ca409f18654d" target="3f78b47b-b744-4def-97d9-016e4cf27d94" archimateRelationship="a9609e08-a8e3-4e25-8f10-7e68029931d2"/>
-        <sourceConnection xsi:type="archimate:Connection" id="08ca6f3c-1768-4b24-88ac-ffd1f0fb34f8" source="d212203a-2da1-48e0-b47b-ca409f18654d" target="3a1c365f-24a6-4c5c-ac2c-ca44cb3c0937" archimateRelationship="c801c856-c345-4a22-9a98-42569a3220bd"/>
-        <sourceConnection xsi:type="archimate:Connection" id="343df1e1-35b5-4e6d-8a2c-88865072cce7" source="d212203a-2da1-48e0-b47b-ca409f18654d" target="b6d5020b-c5a8-4a47-879a-21f84404450b" archimateRelationship="3fdeebe9-63d6-4c7f-911f-820cf135848c"/>
-        <sourceConnection xsi:type="archimate:Connection" id="e220f2a5-c626-4392-a016-b656c546e9b4" source="d212203a-2da1-48e0-b47b-ca409f18654d" target="21f19658-f9c3-470f-a698-16e8bae88ee2" archimateRelationship="e94b7f72-17c2-4873-b380-d13b4d41bac5"/>
-        <child xsi:type="archimate:DiagramObject" id="420bc620-3fde-4bcf-bee7-6aa87c775412" targetConnections="d1f4584d-f610-4064-b73d-4987329a997a 39f08a36-983a-4a4e-b3ef-66725829c6ec 37ebc24a-d2bd-4689-ae86-e00361e4ae19" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
+        <child xsi:type="archimate:DiagramObject" id="420bc620-3fde-4bcf-bee7-6aa87c775412" targetConnections="d1f4584d-f610-4064-b73d-4987329a997a 39f08a36-983a-4a4e-b3ef-66725829c6ec" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
           <bounds x="24" y="48" width="144" height="65"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="3f78b47b-b744-4def-97d9-016e4cf27d94" targetConnections="ea53734c-fcea-4246-acb7-161e80e6a54e 2ae5d749-e8ff-4c19-b580-3d399db3d47c" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
+        <child xsi:type="archimate:DiagramObject" id="3f78b47b-b744-4def-97d9-016e4cf27d94" targetConnections="ea53734c-fcea-4246-acb7-161e80e6a54e" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
           <bounds x="24" y="132" width="144" height="65"/>
           <sourceConnection xsi:type="archimate:Connection" id="e5a12541-0f9e-4ad0-90e6-146f82929abe" source="3f78b47b-b744-4def-97d9-016e4cf27d94" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="8ea14bb7-705c-4a3f-9fb7-40f18af5afbb"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="3a1c365f-24a6-4c5c-ac2c-ca44cb3c0937" targetConnections="c651da22-f77f-4c99-b222-3e509f963433 08ca6f3c-1768-4b24-88ac-ffd1f0fb34f8" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
+        <child xsi:type="archimate:DiagramObject" id="3a1c365f-24a6-4c5c-ac2c-ca44cb3c0937" targetConnections="c651da22-f77f-4c99-b222-3e509f963433" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
           <bounds x="24" y="216" width="144" height="65"/>
           <sourceConnection xsi:type="archimate:Connection" id="d6983425-ccf8-48a9-9059-fa2c48d8c133" source="3a1c365f-24a6-4c5c-ac2c-ca44cb3c0937" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="496117f5-e3ac-4e8c-be72-cfcab9cc996b"/>
         </child>
@@ -829,49 +685,44 @@
           <sourceConnection xsi:type="archimate:Connection" id="39f08a36-983a-4a4e-b3ef-66725829c6ec" source="c2969638-4b19-45d0-9dce-eb8e07c61a8d" target="420bc620-3fde-4bcf-bee7-6aa87c775412" archimateRelationship="0a90aced-35fd-499f-8aee-26de44bf636c"/>
           <sourceConnection xsi:type="archimate:Connection" id="c651da22-f77f-4c99-b222-3e509f963433" source="c2969638-4b19-45d0-9dce-eb8e07c61a8d" target="3a1c365f-24a6-4c5c-ac2c-ca44cb3c0937" archimateRelationship="4565571a-58a5-4483-9551-4dc1600b45c1"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="b6d5020b-c5a8-4a47-879a-21f84404450b" targetConnections="343df1e1-35b5-4e6d-8a2c-88865072cce7" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
+        <child xsi:type="archimate:DiagramObject" id="b6d5020b-c5a8-4a47-879a-21f84404450b" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
           <bounds x="480" y="120" width="133" height="108"/>
           <sourceConnection xsi:type="archimate:Connection" id="eff689e3-c353-48f2-8fe1-775d8c5a4dee" source="b6d5020b-c5a8-4a47-879a-21f84404450b" target="c2969638-4b19-45d0-9dce-eb8e07c61a8d" archimateRelationship="c03146a8-2273-424b-bc6d-c2dd86f93e5c"/>
           <sourceConnection xsi:type="archimate:Connection" id="30b898a7-30ca-4766-b851-eb6dd7a5e225" source="b6d5020b-c5a8-4a47-879a-21f84404450b" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="6b11f94c-fad5-4ef3-acde-3a77b7cc9b4b">
             <bendpoint startX="-500" startY="10" endX="500" endY="30"/>
           </sourceConnection>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="21f19658-f9c3-470f-a698-16e8bae88ee2" targetConnections="e220f2a5-c626-4392-a016-b656c546e9b4" archimateElement="819e7e8c-a185-4b7b-b205-940fefcfe408">
+        <child xsi:type="archimate:DiagramObject" id="21f19658-f9c3-470f-a698-16e8bae88ee2" archimateElement="819e7e8c-a185-4b7b-b205-940fefcfe408">
           <bounds x="24" y="300" width="144" height="65"/>
           <sourceConnection xsi:type="archimate:Connection" id="292d166c-1168-425b-9f5f-f03cbf6b0eb5" source="21f19658-f9c3-470f-a698-16e8bae88ee2" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="89cb6502-27b4-4e3f-9003-025e782532c8"/>
         </child>
       </child>
       <child xsi:type="archimate:DiagramObject" id="92941f14-6fa4-48f8-868a-9ddf12504b09" archimateElement="212f31b8-928f-4714-8aa2-542ecdb81468">
         <bounds x="132" y="24" width="610" height="396"/>
-        <sourceConnection xsi:type="archimate:Connection" id="73a43d5f-d35d-48d9-ba66-e76dc825ed9d" source="92941f14-6fa4-48f8-868a-9ddf12504b09" target="9519245d-597d-4158-bda9-63c1e72c08df" archimateRelationship="db710967-fa2b-4904-87d4-5d28e548a07d"/>
-        <sourceConnection xsi:type="archimate:Connection" id="eb2d5f69-0c53-4fcb-b2e4-910c6172efc4" source="92941f14-6fa4-48f8-868a-9ddf12504b09" target="cf36706e-6496-4990-8e6c-c594a49e4183" archimateRelationship="30ba6a82-c6d3-4a27-83ce-9d8cde8750bd"/>
-        <sourceConnection xsi:type="archimate:Connection" id="0aaf8b2d-50ac-4367-b7da-c03386cc978f" source="92941f14-6fa4-48f8-868a-9ddf12504b09" target="1819c482-5a73-411c-8fb1-28f341e67679" archimateRelationship="b57e920c-ff16-47af-8706-b277376ee747"/>
-        <sourceConnection xsi:type="archimate:Connection" id="27e77df4-fb72-4b2e-8b24-76f1ec8bb24e" source="92941f14-6fa4-48f8-868a-9ddf12504b09" target="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" archimateRelationship="8adf2b0b-3bd8-40ce-8a75-a5e29b7aaa84"/>
-        <sourceConnection xsi:type="archimate:Connection" id="80281249-16ce-4ab1-a2d0-8e79a231ec27" source="92941f14-6fa4-48f8-868a-9ddf12504b09" target="52366da1-8872-484a-8954-dcba5c8b049b" archimateRelationship="a5bb98eb-6c1d-4921-a9c0-98c9aad8aad6"/>
-        <child xsi:type="archimate:DiagramObject" id="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" targetConnections="27e77df4-fb72-4b2e-8b24-76f1ec8bb24e" archimateElement="556907f5-b628-43fb-845c-db9cb756483a">
+        <child xsi:type="archimate:DiagramObject" id="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" archimateElement="556907f5-b628-43fb-845c-db9cb756483a">
           <bounds x="228" y="96" width="132" height="79"/>
           <sourceConnection xsi:type="archimate:Connection" id="72b9d3a9-1063-4b82-a16e-6b2d58b58cd8" source="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" target="9519245d-597d-4158-bda9-63c1e72c08df" archimateRelationship="6ac270e4-3520-44ba-8784-77f217b03887"/>
           <sourceConnection xsi:type="archimate:Connection" id="48ac5f9c-fffc-40f6-b18a-1f0435889e7b" source="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" target="cf36706e-6496-4990-8e6c-c594a49e4183" archimateRelationship="95c2def0-63c5-47e6-a79e-2ae528a5740d"/>
           <sourceConnection xsi:type="archimate:Connection" id="b6e329fc-39ab-4242-bf55-f182ffd95653" source="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" target="0da61933-9bf8-4240-a707-a04021678ec7" archimateRelationship="7d00fe16-6ca1-4950-8365-1945ab74a12f"/>
           <sourceConnection xsi:type="archimate:Connection" id="1c4aa629-5b71-4700-9dd7-92cf52af8145" source="fc9b7a95-45de-4e16-bca6-88e3c6d406b6" target="1819c482-5a73-411c-8fb1-28f341e67679" archimateRelationship="9063ad94-b467-48df-97c6-3d97233391ce"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="1819c482-5a73-411c-8fb1-28f341e67679" targetConnections="0aaf8b2d-50ac-4367-b7da-c03386cc978f 1c4aa629-5b71-4700-9dd7-92cf52af8145" archimateElement="c2bcebbc-2082-490d-aa5f-8606e59e3833">
+        <child xsi:type="archimate:DiagramObject" id="1819c482-5a73-411c-8fb1-28f341e67679" targetConnections="1c4aa629-5b71-4700-9dd7-92cf52af8145" archimateElement="c2bcebbc-2082-490d-aa5f-8606e59e3833">
           <bounds x="444" y="216" width="144" height="65"/>
           <sourceConnection xsi:type="archimate:Connection" id="37dc4e7b-b9be-4df6-b38b-73ff22db929e" source="1819c482-5a73-411c-8fb1-28f341e67679" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="30c84a11-4798-4a9c-9840-d23053e7bd53"/>
         </child>
         <child xsi:type="archimate:DiagramObject" id="0da61933-9bf8-4240-a707-a04021678ec7" targetConnections="848912ca-a1cb-43d7-b58b-548fa642a923 b6e329fc-39ab-4242-bf55-f182ffd95653" archimateElement="538aa797-e00b-442f-af83-9a8e7e85aadd">
           <bounds x="444" y="48" width="144" height="65"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="cf36706e-6496-4990-8e6c-c594a49e4183" targetConnections="eb2d5f69-0c53-4fcb-b2e4-910c6172efc4 3f723213-4be1-48ef-9c93-322befe674bd 48ac5f9c-fffc-40f6-b18a-1f0435889e7b" archimateElement="a46b13f6-899f-4651-bccd-67685ea0ab9d">
+        <child xsi:type="archimate:DiagramObject" id="cf36706e-6496-4990-8e6c-c594a49e4183" targetConnections="3f723213-4be1-48ef-9c93-322befe674bd 48ac5f9c-fffc-40f6-b18a-1f0435889e7b" archimateElement="a46b13f6-899f-4651-bccd-67685ea0ab9d">
           <bounds x="444" y="132" width="144" height="65"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="9519245d-597d-4158-bda9-63c1e72c08df" targetConnections="73a43d5f-d35d-48d9-ba66-e76dc825ed9d 72b9d3a9-1063-4b82-a16e-6b2d58b58cd8" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
+        <child xsi:type="archimate:DiagramObject" id="9519245d-597d-4158-bda9-63c1e72c08df" targetConnections="72b9d3a9-1063-4b82-a16e-6b2d58b58cd8" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
           <bounds x="24" y="108" width="133" height="108"/>
           <sourceConnection xsi:type="archimate:Connection" id="8be11109-bb70-4b85-8a5b-9f1114a57907" source="9519245d-597d-4158-bda9-63c1e72c08df" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="faf184fe-1470-45c9-9e0f-e4bc4b26aa32">
             <bendpoint startX="380" startY="14" endX="-386" endY="30"/>
           </sourceConnection>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="52366da1-8872-484a-8954-dcba5c8b049b" targetConnections="80281249-16ce-4ab1-a2d0-8e79a231ec27" archimateElement="17bc30f6-6291-43bc-b2e5-ef5202bc18e4">
+        <child xsi:type="archimate:DiagramObject" id="52366da1-8872-484a-8954-dcba5c8b049b" archimateElement="17bc30f6-6291-43bc-b2e5-ef5202bc18e4">
           <bounds x="444" y="300" width="144" height="65"/>
           <sourceConnection xsi:type="archimate:Connection" id="9bb697f1-4a75-4882-8358-e558fbf99e2a" source="52366da1-8872-484a-8954-dcba5c8b049b" target="fe525f10-a933-4d6e-b29a-65f1d5d18930" archimateRelationship="7cc89761-4fb9-4a12-b8a3-a041f3e331cc"/>
         </child>
@@ -894,156 +745,44 @@
       </child>
     </element>
     <element xsi:type="archimate:ArchimateDiagramModel" name="Deployment topology #1" id="9f0ecd93-71c9-4fc3-b3b5-cb3422874279">
-      <child xsi:type="archimate:DiagramObject" id="cc8a2532-35b1-496a-bea5-5167a3b74583" archimateElement="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac">
-        <bounds x="1152" y="16" width="674" height="978"/>
-        <sourceConnection xsi:type="archimate:Connection" id="5919a566-6928-466a-a832-4d761a1b02fc" source="cc8a2532-35b1-496a-bea5-5167a3b74583" target="ae4559fc-cf9a-47a8-8b71-4b23a916c468" archimateRelationship="17b2804b-bcb2-400f-b93c-827ca8523d9e"/>
-        <sourceConnection xsi:type="archimate:Connection" id="7d7d7a4c-e6d2-4c17-9e25-9674e001a815" source="cc8a2532-35b1-496a-bea5-5167a3b74583" target="ae4559fc-cf9a-47a8-8b71-4b23a916c468" archimateRelationship="17b2804b-bcb2-400f-b93c-827ca8523d9e"/>
-        <sourceConnection xsi:type="archimate:Connection" id="765fe292-a8cf-459a-bf29-c7845a8ff235" source="cc8a2532-35b1-496a-bea5-5167a3b74583" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="3fdeebe9-63d6-4c7f-911f-820cf135848c"/>
-        <sourceConnection xsi:type="archimate:Connection" id="679594de-509f-44a4-ba70-550396ada5d0" source="cc8a2532-35b1-496a-bea5-5167a3b74583" target="039e3b6f-93ce-418e-8c67-f7d608b9bab3" archimateRelationship="a9609e08-a8e3-4e25-8f10-7e68029931d2"/>
-        <sourceConnection xsi:type="archimate:Connection" id="8a3b33b9-83e9-4669-b90c-edef0c16ff1c" source="cc8a2532-35b1-496a-bea5-5167a3b74583" target="ac0da59a-a9b6-447a-a997-b63e18573dc5" archimateRelationship="c801c856-c345-4a22-9a98-42569a3220bd"/>
-        <child xsi:type="archimate:DiagramObject" id="ae4559fc-cf9a-47a8-8b71-4b23a916c468" targetConnections="5919a566-6928-466a-a832-4d761a1b02fc 7d7d7a4c-e6d2-4c17-9e25-9674e001a815" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
-          <bounds x="65" y="29" width="196" height="105"/>
-          <sourceConnection xsi:type="archimate:Connection" id="722992ef-c758-4f34-92d7-31afeb047c65" source="ae4559fc-cf9a-47a8-8b71-4b23a916c468" target="fd503229-02f9-40f7-aeaa-5bb72030a899" archimateRelationship="b85300bf-77ed-49c7-84a8-011be915cee2"/>
-          <sourceConnection xsi:type="archimate:Connection" id="a9d606af-1e06-41f5-887f-36f8fbfade49" source="ae4559fc-cf9a-47a8-8b71-4b23a916c468" target="322d2fa3-56ad-43e4-96e3-f64f733ed393" archimateRelationship="885e9e6f-9da6-4924-8aaf-d8c5ab20552b"/>
-          <child xsi:type="archimate:DiagramObject" id="fd503229-02f9-40f7-aeaa-5bb72030a899" targetConnections="722992ef-c758-4f34-92d7-31afeb047c65" archimateElement="68e59636-1f53-4336-9cfd-64fa6acae825">
-            <bounds x="14" y="40" width="151" height="55"/>
-            <sourceConnection xsi:type="archimate:Connection" id="6d91fde9-7faf-4783-a5f4-3500ca5de394" source="fd503229-02f9-40f7-aeaa-5bb72030a899" target="0d9cde6f-9382-479a-90d5-5515d57636c8" archimateRelationship="caab7f6b-ecb8-4257-85ef-bbff50ef681b"/>
-          </child>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="4cbbb745-e6ea-4aee-977d-2178183f4ec2" targetConnections="765fe292-a8cf-459a-bf29-c7845a8ff235 a8e3b84c-e756-4133-9d36-ab930d551cc0 7a3a94ec-ad77-4226-83c0-b2a8ca1c7fbc 70c94ee9-a972-4c1b-9235-130ca7751371 b14bb356-0b52-4c71-b0fa-ea36f0d27070" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
-          <bounds x="365" y="352" width="274" height="271"/>
-          <sourceConnection xsi:type="archimate:Connection" id="5a839017-abee-4fd2-a366-bdcc4915c4fe" source="4cbbb745-e6ea-4aee-977d-2178183f4ec2" target="72327a87-82a9-4f3f-98db-1c358ab5b6df" archimateRelationship="fec9ce18-5dfb-4483-b947-1d4dd4709b45"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="039e3b6f-93ce-418e-8c67-f7d608b9bab3" targetConnections="679594de-509f-44a4-ba70-550396ada5d0 88994f40-85e0-4745-850b-0816b5fe1bed" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
-          <bounds x="64" y="567" width="194" height="103"/>
-          <sourceConnection xsi:type="archimate:Connection" id="14b33f6c-8fbb-4b98-ab69-c813a1b57aca" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="454f2fd3-e258-4bc8-95d6-a5cfb9c4cdd1" archimateRelationship="dd6d220f-2e28-4568-9b32-05078dd07d50"/>
-          <sourceConnection xsi:type="archimate:Connection" id="260d4613-78a3-4e5b-ae76-097bd7787447" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" archimateRelationship="3de150e4-3c9e-45ad-9c44-fc2dccf967a3">
-            <bendpoint startX="-82" startY="-145" endX="290" endY="36"/>
-          </sourceConnection>
-          <sourceConnection xsi:type="archimate:Connection" id="a8e3b84c-e756-4133-9d36-ab930d551cc0" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="ce7896f2-7830-4829-bc08-5d822b5ac10b"/>
-          <sourceConnection xsi:type="archimate:Connection" id="b52af52d-d20e-430b-a883-a49a5acb2f6b" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="1a65f425-6273-4339-badf-15bc2122b7fa">
-            <bendpoint startX="-186" startY="-18" endX="878" endY="53"/>
-            <bendpoint startX="-192" startY="-103" endX="882" endY="34"/>
-            <bendpoint startX="-519" startY="-76" endX="545" endY="-6"/>
-          </sourceConnection>
-          <sourceConnection xsi:type="archimate:Connection" id="b4a92e65-f269-4400-9519-05a1dc26d63b" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="2da9702d-601c-44de-9b5f-8ca13b2ce338" archimateRelationship="0bef2725-e92f-4ade-887e-3bd76eab034c"/>
-          <child xsi:type="archimate:DiagramObject" id="454f2fd3-e258-4bc8-95d6-a5cfb9c4cdd1" targetConnections="14b33f6c-8fbb-4b98-ab69-c813a1b57aca" archimateElement="1a8879f8-06ce-4925-93ab-ff2222e347aa">
-            <bounds x="21" y="41" width="133" height="55"/>
-          </child>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="ac0da59a-a9b6-447a-a997-b63e18573dc5" targetConnections="8a3b33b9-83e9-4669-b90c-edef0c16ff1c d55b5255-5a38-4c3d-924c-102ceb0070ff" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
-          <bounds x="67" y="820" width="196" height="105"/>
-          <sourceConnection xsi:type="archimate:Connection" id="8b1528bb-d013-4d6c-abc8-c3ce341659b5" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="9404da78-8721-4fa9-b367-b99217b83f22" archimateRelationship="67b2f7a1-c01c-464b-8caa-b4a9744f35ae"/>
-          <sourceConnection xsi:type="archimate:Connection" id="7a3a94ec-ad77-4226-83c0-b2a8ca1c7fbc" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="59d8bd29-7642-49a0-9c2f-48b13fa3fdfc">
-            <bendpoint startX="338" startY="1" endX="-2" endY="356"/>
-          </sourceConnection>
-          <sourceConnection xsi:type="archimate:Connection" id="88c62c2e-8249-43d0-b8a7-86b4ac12694e" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" archimateRelationship="0e0d90ea-f06a-414b-9eab-4e425f96d110"/>
-          <sourceConnection xsi:type="archimate:Connection" id="ded17a8a-f591-460f-8b90-be187b7e5fa3" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="88af58c4-9adf-4338-a54b-352b34d04b76" archimateRelationship="bf3a3e9b-d6d1-4989-8ef7-021d1f136913"/>
-          <child xsi:type="archimate:DiagramObject" id="9404da78-8721-4fa9-b367-b99217b83f22" targetConnections="8b1528bb-d013-4d6c-abc8-c3ce341659b5" archimateElement="51eacaa9-ed7b-4307-915c-05a114b2a19d">
-            <bounds x="21" y="41" width="141" height="55"/>
-          </child>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="2da9702d-601c-44de-9b5f-8ca13b2ce338" targetConnections="b4a92e65-f269-4400-9519-05a1dc26d63b" archimateElement="9dc22627-f969-46c8-ac76-9f1ac9b35767" type="1">
-          <bounds x="64" y="496" width="194" height="43"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="72327a87-82a9-4f3f-98db-1c358ab5b6df" targetConnections="5a839017-abee-4fd2-a366-bdcc4915c4fe" archimateElement="0984a188-6642-400c-a42f-20277624eee9" type="1">
-          <bounds x="365" y="223" width="274" height="93"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="88af58c4-9adf-4338-a54b-352b34d04b76" targetConnections="ded17a8a-f591-460f-8b90-be187b7e5fa3" archimateElement="7c846708-edd4-4a3a-afad-a711b21abeb4" type="1">
-          <bounds x="67" y="741" width="196" height="55"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="0d9cde6f-9382-479a-90d5-5515d57636c8" targetConnections="6d91fde9-7faf-4783-a5f4-3500ca5de394" archimateElement="197d58a5-2131-41e0-8ec3-37bc46ed9b3d" type="1">
-          <bounds x="365" y="57" width="129" height="68"/>
-        </child>
+      <child xsi:type="archimate:DiagramObject" id="63ecb780-4b72-48f7-8e69-969345a6f3f4" fillColor="#fefc78" archimateElement="0077ac29-da6d-426c-90a0-51e987d5f202">
+        <bounds x="780" y="120" width="309" height="1092"/>
       </child>
-      <child xsi:type="archimate:DiagramObject" id="c7defef5-09d4-41c1-a76d-da3e521419c5" archimateElement="efbf9f7a-7b30-462f-a471-3cc2049014b5">
-        <bounds x="770" y="16" width="362" height="978"/>
-        <sourceConnection xsi:type="archimate:Connection" id="163aacdb-5bef-40db-9b82-d21ffe3175aa" source="c7defef5-09d4-41c1-a76d-da3e521419c5" target="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" archimateRelationship="f28c0a1d-12f1-4f22-9add-268879bc8a51"/>
-        <sourceConnection xsi:type="archimate:Connection" id="f60dd721-1d5f-49a6-863b-804af74a7ce4" source="c7defef5-09d4-41c1-a76d-da3e521419c5" target="22f86c10-9ab5-46f0-937a-5b6f932871d5" archimateRelationship="b42e098e-f8e9-48a6-9786-1de691e9e707"/>
-        <sourceConnection xsi:type="archimate:Connection" id="ccb78894-4cbf-4ed2-86b4-23bef3675d82" source="c7defef5-09d4-41c1-a76d-da3e521419c5" target="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" archimateRelationship="8061137c-057b-42fe-b50e-08493914d415"/>
-        <child xsi:type="archimate:DiagramObject" id="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" targetConnections="163aacdb-5bef-40db-9b82-d21ffe3175aa 7d504256-873f-49e8-ba1c-7203b9ba1c14" archimateElement="8532f211-fbcb-4255-a32d-91871c7336be">
-          <bounds x="68" y="716" width="205" height="78"/>
-          <sourceConnection xsi:type="archimate:Connection" id="70c94ee9-a972-4c1b-9235-130ca7751371" source="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="604120c2-2acc-4b05-a43d-c707a73ad5dc">
-            <bendpoint startX="657" endX="-80" endY="239"/>
-          </sourceConnection>
-          <sourceConnection xsi:type="archimate:Connection" id="3e3c38fa-20f6-451d-b15d-2451986cff47" source="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="b8077982-bc5b-42e6-baad-9a371e82443c">
-            <bendpoint startX="-627" startY="6" endX="61" endY="245"/>
-          </sourceConnection>
+      <child xsi:type="archimate:DiagramObject" id="bf37c088-c83f-402a-9b52-face97ad58d0" fillColor="#fefc78" archimateElement="2c9f4633-1900-40f9-9ea1-3758509a1381">
+        <bounds x="432" y="120" width="309" height="1093"/>
+        <child xsi:type="archimate:DiagramObject" id="c597dd75-a908-492e-b3b2-e93e8273e81c" targetConnections="e7b59793-4e36-45a2-bb89-87bd90810527" archimateElement="b7b2aa18-f4d7-4341-945c-03837cb989a6" type="1">
+          <bounds x="60" y="876" width="194" height="55"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="22f86c10-9ab5-46f0-937a-5b6f932871d5" targetConnections="f60dd721-1d5f-49a6-863b-804af74a7ce4" archimateElement="98f08e2a-55bb-4cf3-88f8-a72c328068e1">
-          <bounds x="68" y="594" width="205" height="100"/>
-          <sourceConnection xsi:type="archimate:Connection" id="1e49dc22-018d-44fc-b41c-6ffcd057e7d3" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="521a3ab7-857d-4319-b150-848d7e62010a" archimateRelationship="f4d55798-6548-4f2b-8a36-dfb103680504"/>
-          <sourceConnection xsi:type="archimate:Connection" id="7d504256-873f-49e8-ba1c-7203b9ba1c14" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" archimateRelationship="4ccd9580-1076-4ab8-9e7c-51b10d00aa48"/>
-          <sourceConnection xsi:type="archimate:Connection" id="88994f40-85e0-4745-850b-0816b5fe1bed" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="039e3b6f-93ce-418e-8c67-f7d608b9bab3" archimateRelationship="b1837450-f7fb-4eb5-8d35-95206ec0ad1c"/>
-          <sourceConnection xsi:type="archimate:Connection" id="496da764-66cb-4cc2-bad1-b2c5b2c3f094" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="7551b95a-b261-4058-8d05-12e2b1b33b70" archimateRelationship="dbe8aa22-0fa9-4cf4-9585-78e68a698731"/>
-          <child xsi:type="archimate:DiagramObject" id="521a3ab7-857d-4319-b150-848d7e62010a" targetConnections="1e49dc22-018d-44fc-b41c-6ffcd057e7d3" archimateElement="e573296a-1aac-4c71-871c-1baf2417c996">
-            <bounds x="17" y="45" width="152" height="47"/>
-          </child>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" targetConnections="260d4613-78a3-4e5b-ae76-097bd7787447 ccb78894-4cbf-4ed2-86b4-23bef3675d82" archimateElement="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe">
-          <bounds x="68" y="381" width="205" height="113"/>
-          <sourceConnection xsi:type="archimate:Connection" id="7248a965-43e8-4069-97bf-b5b796f79751" source="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" target="1561f4ae-0fff-4436-97ca-b2e9347b0186" archimateRelationship="3ca5b18c-b380-4be6-95f6-d6301b907ef5"/>
-          <sourceConnection xsi:type="archimate:Connection" id="2cdfbe62-9fb3-421d-bd23-f47f9b92b83a" source="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="6188230a-d639-46ea-9351-4bd0e798f98e"/>
-          <sourceConnection xsi:type="archimate:Connection" id="7e680171-eb4e-4d4e-931a-8da5b30f10ca" source="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" target="f99d35cb-eade-4648-9f73-718fa8155c97" archimateRelationship="8d9b2549-3ec1-40a7-a2bf-709d6c667325"/>
-          <child xsi:type="archimate:DiagramObject" id="1561f4ae-0fff-4436-97ca-b2e9347b0186" targetConnections="7248a965-43e8-4069-97bf-b5b796f79751" archimateElement="10cb9a93-25d4-4da1-8964-c183b3ff910c">
-            <bounds x="20" y="47" width="152" height="55"/>
-          </child>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="e1337d67-2fc2-4f98-b87e-446c41cd22a5" archimateElement="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349">
-          <bounds x="70" y="185" width="204" height="109"/>
-          <sourceConnection xsi:type="archimate:Connection" id="98c0b577-10d7-4b50-a784-f587880399ea" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="289762f7-5dbc-47d6-b151-929e3c48c7a1" archimateRelationship="3dfc3dbf-5711-45b6-930a-0dc44678676a"/>
-          <sourceConnection xsi:type="archimate:Connection" id="b14bb356-0b52-4c71-b0fa-ea36f0d27070" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="9102c6a7-d07f-4de0-94d7-273bb7bca236">
-            <bendpoint startX="409" startY="17" endX="-307" endY="-215"/>
-            <bendpoint startX="410" startY="142" endX="-306" endY="-90"/>
-          </sourceConnection>
-          <sourceConnection xsi:type="archimate:Connection" id="8202fcb6-2a06-42ed-acd7-5092c9c7e32b" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="5ad8159f-f033-40fd-977d-34f2694d728b">
-            <bendpoint startX="-307" startY="16" endX="394" endY="-210"/>
-            <bendpoint startX="-296" startY="134" endX="391" endY="-98"/>
-          </sourceConnection>
-          <sourceConnection xsi:type="archimate:Connection" id="e82ecd83-1ab0-4fd7-9d1b-d008d447df6f" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="12a02288-f1ba-4dc8-803a-dd87c10bdd00" archimateRelationship="e08143cb-a72b-4f01-b442-a8c905603be7"/>
-          <child xsi:type="archimate:DiagramObject" id="289762f7-5dbc-47d6-b151-929e3c48c7a1" targetConnections="98c0b577-10d7-4b50-a784-f587880399ea" archimateElement="fede8dba-b24e-4347-9487-e9901da917f9">
-            <bounds x="22" y="52" width="148" height="47"/>
-          </child>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="f99d35cb-eade-4648-9f73-718fa8155c97" targetConnections="7e680171-eb4e-4d4e-931a-8da5b30f10ca" archimateElement="83a086f5-68c0-475d-88e8-c53fc033a533" type="1">
-          <bounds x="69" y="307" width="205" height="43"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="12a02288-f1ba-4dc8-803a-dd87c10bdd00" targetConnections="e82ecd83-1ab0-4fd7-9d1b-d008d447df6f" archimateElement="5647d2da-812c-4a0f-af6e-bac94daa4aeb" type="1">
-          <bounds x="68" y="93" width="204" height="55"/>
-        </child>
-      </child>
-      <child xsi:type="archimate:DiagramObject" id="47e32f77-111c-490b-b5d4-98b713f7e7bc" archimateElement="212f31b8-928f-4714-8aa2-542ecdb81468">
-        <bounds x="72" y="16" width="674" height="978"/>
-        <sourceConnection xsi:type="archimate:Connection" id="1e20837a-b01d-4693-a0bc-4edb09609972" source="47e32f77-111c-490b-b5d4-98b713f7e7bc" target="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" archimateRelationship="b57e920c-ff16-47af-8706-b277376ee747"/>
-        <sourceConnection xsi:type="archimate:Connection" id="e809c647-c0c6-411e-8eed-eddd71587e50" source="47e32f77-111c-490b-b5d4-98b713f7e7bc" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="db710967-fa2b-4904-87d4-5d28e548a07d"/>
-        <sourceConnection xsi:type="archimate:Connection" id="a74b3e65-6579-45ed-9ab8-37a581b54c01" source="47e32f77-111c-490b-b5d4-98b713f7e7bc" target="7551b95a-b261-4058-8d05-12e2b1b33b70" archimateRelationship="30ba6a82-c6d3-4a27-83ce-9d8cde8750bd"/>
-        <child xsi:type="archimate:DiagramObject" id="7551b95a-b261-4058-8d05-12e2b1b33b70" targetConnections="a74b3e65-6579-45ed-9ab8-37a581b54c01 496da764-66cb-4cc2-bad1-b2c5b2c3f094" archimateElement="a46b13f6-899f-4651-bccd-67685ea0ab9d">
-          <bounds x="409" y="572" width="194" height="103"/>
-          <sourceConnection xsi:type="archimate:Connection" id="a1936d07-6c4c-457c-895c-876da16d7561" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="00c4a55a-5ec6-42e1-91fc-de97c090c9ec"/>
-          <sourceConnection xsi:type="archimate:Connection" id="6cb388b0-1f6f-4428-b5fd-f7b6b53b4d97" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="a9247692-5ec4-4f7d-b797-9f6d750eef2c" archimateRelationship="6652b746-6c44-479c-b3e9-5f901199d7ef"/>
-          <sourceConnection xsi:type="archimate:Connection" id="85cd0674-d91f-423f-aae4-eda86998820b" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="27c6d20e-a463-43c0-a923-2e097816b34b" archimateRelationship="32f934ac-0d3b-43d1-9f47-447f6e564ba7"/>
-          <child xsi:type="archimate:DiagramObject" id="a9247692-5ec4-4f7d-b797-9f6d750eef2c" targetConnections="6cb388b0-1f6f-4428-b5fd-f7b6b53b4d97" archimateElement="8efc3e85-150e-4e1d-91f5-8989b1c5b89f">
-            <bounds x="21" y="41" width="133" height="55"/>
-          </child>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" targetConnections="cc3457cb-c306-4a3c-abec-c76682da886f 79075b5b-919e-421c-8e84-12e0193315fc a1936d07-6c4c-457c-895c-876da16d7561 e809c647-c0c6-411e-8eed-eddd71587e50 8202fcb6-2a06-42ed-acd7-5092c9c7e32b 2cdfbe62-9fb3-421d-bd23-f47f9b92b83a 3e3c38fa-20f6-451d-b15d-2451986cff47 b52af52d-d20e-430b-a883-a49a5acb2f6b" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
-          <bounds x="30" y="345" width="274" height="271"/>
-          <sourceConnection xsi:type="archimate:Connection" id="5012fc94-bb3f-4169-bd3c-125c69d8476d" source="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" target="af1e1f82-d762-4e1c-b94c-28a68482a967" archimateRelationship="65eeae27-537c-48c0-9390-455f475c2800"/>
-        </child>
-        <child xsi:type="archimate:DiagramObject" id="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" targetConnections="1e20837a-b01d-4693-a0bc-4edb09609972 88c62c2e-8249-43d0-b8a7-86b4ac12694e" archimateElement="c2bcebbc-2082-490d-aa5f-8606e59e3833">
-          <bounds x="411" y="826" width="196" height="105"/>
+        <child xsi:type="archimate:DiagramObject" id="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" targetConnections="88c62c2e-8249-43d0-b8a7-86b4ac12694e" archimateElement="c2bcebbc-2082-490d-aa5f-8606e59e3833">
+          <bounds x="60" y="960" width="194" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="e7b59793-4e36-45a2-bb89-87bd90810527" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="c597dd75-a908-492e-b3b2-e93e8273e81c" archimateRelationship="d965cc0d-8876-416d-a61a-e12259efd4f9"/>
           <sourceConnection xsi:type="archimate:Connection" id="d2481ae9-a94a-4dc6-a1df-4719e46e21ca" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="de9260ad-5f12-48cf-a893-56a0aa37e98a" archimateRelationship="c63e1909-e2fe-4516-b642-d6749c9ad79c"/>
           <sourceConnection xsi:type="archimate:Connection" id="d55b5255-5a38-4c3d-924c-102ceb0070ff" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="ac0da59a-a9b6-447a-a997-b63e18573dc5" archimateRelationship="bce71955-7d5f-4f3d-a47c-a5b0b5af71d8"/>
           <sourceConnection xsi:type="archimate:Connection" id="79075b5b-919e-421c-8e84-12e0193315fc" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="254d9661-8126-4963-8d40-e57116fa4186">
             <bendpoint startX="-356" startY="5" endX="-14" endY="360"/>
           </sourceConnection>
-          <sourceConnection xsi:type="archimate:Connection" id="e7b59793-4e36-45a2-bb89-87bd90810527" source="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" target="c597dd75-a908-492e-b3b2-e93e8273e81c" archimateRelationship="d965cc0d-8876-416d-a61a-e12259efd4f9"/>
           <child xsi:type="archimate:DiagramObject" id="de9260ad-5f12-48cf-a893-56a0aa37e98a" targetConnections="d2481ae9-a94a-4dc6-a1df-4719e46e21ca" archimateElement="cc875beb-f4ff-4952-9600-5eae35fb0d10">
             <bounds x="21" y="41" width="141" height="55"/>
           </child>
         </child>
+        <child xsi:type="archimate:DiagramObject" id="7551b95a-b261-4058-8d05-12e2b1b33b70" targetConnections="496da764-66cb-4cc2-bad1-b2c5b2c3f094" archimateElement="a46b13f6-899f-4651-bccd-67685ea0ab9d">
+          <bounds x="60" y="684" width="194" height="103"/>
+          <sourceConnection xsi:type="archimate:Connection" id="85cd0674-d91f-423f-aae4-eda86998820b" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="27c6d20e-a463-43c0-a923-2e097816b34b" archimateRelationship="32f934ac-0d3b-43d1-9f47-447f6e564ba7"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a1936d07-6c4c-457c-895c-876da16d7561" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="00c4a55a-5ec6-42e1-91fc-de97c090c9ec"/>
+          <sourceConnection xsi:type="archimate:Connection" id="6cb388b0-1f6f-4428-b5fd-f7b6b53b4d97" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="a9247692-5ec4-4f7d-b797-9f6d750eef2c" archimateRelationship="6652b746-6c44-479c-b3e9-5f901199d7ef"/>
+          <sourceConnection xsi:type="archimate:Connection" id="01b72cc3-d955-4da8-8b63-bd56448f9847" source="7551b95a-b261-4058-8d05-12e2b1b33b70" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="424515ef-9f7d-470b-a218-c9f833280361">
+            <bendpoint startX="502" startY="-39" endX="-574" endY="97"/>
+            <bendpoint startX="502" startY="-159" endX="-574" endY="-23"/>
+          </sourceConnection>
+          <child xsi:type="archimate:DiagramObject" id="a9247692-5ec4-4f7d-b797-9f6d750eef2c" targetConnections="6cb388b0-1f6f-4428-b5fd-f7b6b53b4d97" archimateElement="8efc3e85-150e-4e1d-91f5-8989b1c5b89f">
+            <bounds x="21" y="41" width="133" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="27c6d20e-a463-43c0-a923-2e097816b34b" targetConnections="85cd0674-d91f-423f-aae4-eda86998820b" archimateElement="2cc22b82-8760-46b4-80cb-118fb3cb04ee" type="1">
+          <bounds x="60" y="600" width="194" height="43"/>
+        </child>
         <child xsi:type="archimate:DiagramObject" id="322d2fa3-56ad-43e4-96e3-f64f733ed393" targetConnections="a9d606af-1e06-41f5-887f-36f8fbfade49" archimateElement="538aa797-e00b-442f-af83-9a8e7e85aadd">
-          <bounds x="411" y="35" width="196" height="105"/>
+          <bounds x="60" y="144" width="196" height="105"/>
           <sourceConnection xsi:type="archimate:Connection" id="602a2b42-42f8-4124-ba67-e4c03ba0b09e" source="322d2fa3-56ad-43e4-96e3-f64f733ed393" target="8f2f5add-4047-4bbe-a7f2-82f6247599d8" archimateRelationship="49c8dabe-7bb4-4d12-b9c6-1cbd98f0c9a3"/>
           <sourceConnection xsi:type="archimate:Connection" id="cc3457cb-c306-4a3c-abec-c76682da886f" source="322d2fa3-56ad-43e4-96e3-f64f733ed393" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="3a2019bf-1f10-4bd8-9004-073eccf5289a"/>
           <child xsi:type="archimate:DiagramObject" id="8f2f5add-4047-4bbe-a7f2-82f6247599d8" targetConnections="602a2b42-42f8-4124-ba67-e4c03ba0b09e" archimateElement="aae5673b-3220-4959-bd3b-a4351a94194d">
@@ -1051,22 +790,129 @@
             <sourceConnection xsi:type="archimate:Connection" id="23c76cfe-4519-4ee6-99aa-2300581faaf8" source="8f2f5add-4047-4bbe-a7f2-82f6247599d8" target="d0288160-d92d-4888-8bb4-7dfb83b2676f" archimateRelationship="4d511da2-7df6-4beb-b47c-78b2f788e5f5"/>
           </child>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="af1e1f82-d762-4e1c-b94c-28a68482a967" targetConnections="5012fc94-bb3f-4169-bd3c-125c69d8476d" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75" type="1">
-          <bounds x="30" y="214" width="274" height="93"/>
-          <sourceConnection xsi:type="archimate:Connection" id="6f94354e-629a-4ae7-9a3f-5d38214b491e" source="af1e1f82-d762-4e1c-b94c-28a68482a967" target="5562e0e3-7aa7-470f-aa76-641ada75095d" archimateRelationship="8d84949c-da2f-456f-9c85-eb903765cea5"/>
-          <child xsi:type="archimate:DiagramObject" id="5562e0e3-7aa7-470f-aa76-641ada75095d" targetConnections="6f94354e-629a-4ae7-9a3f-5d38214b491e" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" type="1">
-            <bounds x="48" y="26" width="177" height="52"/>
-          </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="a60a31a5-c9b9-4e5d-ac1a-f5276b3ac997" fillColor="#fefc78" archimateElement="cfadf0df-e7a6-4465-ba12-5ad6e915a525">
+        <bounds x="84" y="120" width="309" height="1093"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" targetConnections="cc3457cb-c306-4a3c-abec-c76682da886f 79075b5b-919e-421c-8e84-12e0193315fc a1936d07-6c4c-457c-895c-876da16d7561 b52af52d-d20e-430b-a883-a49a5acb2f6b 8202fcb6-2a06-42ed-acd7-5092c9c7e32b 2cdfbe62-9fb3-421d-bd23-f47f9b92b83a 3e3c38fa-20f6-451d-b15d-2451986cff47" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
+        <bounds x="107" y="572" width="274" height="271"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5012fc94-bb3f-4169-bd3c-125c69d8476d" source="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" target="af1e1f82-d762-4e1c-b94c-28a68482a967" archimateRelationship="65eeae27-537c-48c0-9390-455f475c2800"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="af1e1f82-d762-4e1c-b94c-28a68482a967" targetConnections="5012fc94-bb3f-4169-bd3c-125c69d8476d" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75" type="1">
+        <bounds x="107" y="441" width="274" height="93"/>
+        <sourceConnection xsi:type="archimate:Connection" id="6f94354e-629a-4ae7-9a3f-5d38214b491e" source="af1e1f82-d762-4e1c-b94c-28a68482a967" target="5562e0e3-7aa7-470f-aa76-641ada75095d" archimateRelationship="8d84949c-da2f-456f-9c85-eb903765cea5"/>
+        <child xsi:type="archimate:DiagramObject" id="5562e0e3-7aa7-470f-aa76-641ada75095d" targetConnections="6f94354e-629a-4ae7-9a3f-5d38214b491e" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" type="1">
+          <bounds x="48" y="26" width="177" height="52"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="d0288160-d92d-4888-8bb4-7dfb83b2676f" targetConnections="23c76cfe-4519-4ee6-99aa-2300581faaf8" archimateElement="5e3cba4d-6785-4a6a-80e7-ccabcb45c0e3" type="1">
-          <bounds x="175" y="62" width="129" height="68"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="d0288160-d92d-4888-8bb4-7dfb83b2676f" targetConnections="23c76cfe-4519-4ee6-99aa-2300581faaf8" archimateElement="5e3cba4d-6785-4a6a-80e7-ccabcb45c0e3" type="1">
+        <bounds x="492" y="180" width="193" height="44"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="12a02288-f1ba-4dc8-803a-dd87c10bdd00" targetConnections="e82ecd83-1ab0-4fd7-9d1b-d008d447df6f" archimateElement="5647d2da-812c-4a0f-af6e-bac94daa4aeb" type="1">
+        <bounds x="840" y="349" width="204" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="e1337d67-2fc2-4f98-b87e-446c41cd22a5" archimateElement="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349">
+        <bounds x="842" y="441" width="204" height="109"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e82ecd83-1ab0-4fd7-9d1b-d008d447df6f" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="12a02288-f1ba-4dc8-803a-dd87c10bdd00" archimateRelationship="e08143cb-a72b-4f01-b442-a8c905603be7"/>
+        <sourceConnection xsi:type="archimate:Connection" id="98c0b577-10d7-4b50-a784-f587880399ea" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="289762f7-5dbc-47d6-b151-929e3c48c7a1" archimateRelationship="3dfc3dbf-5711-45b6-930a-0dc44678676a"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8202fcb6-2a06-42ed-acd7-5092c9c7e32b" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="5ad8159f-f033-40fd-977d-34f2694d728b">
+          <bendpoint startX="-307" startY="16" endX="394" endY="-210"/>
+          <bendpoint startX="-296" startY="134" endX="391" endY="-98"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="b14bb356-0b52-4c71-b0fa-ea36f0d27070" source="e1337d67-2fc2-4f98-b87e-446c41cd22a5" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="9102c6a7-d07f-4de0-94d7-273bb7bca236">
+          <bendpoint startX="409" startY="17" endX="-307" endY="-215"/>
+          <bendpoint startX="410" startY="142" endX="-306" endY="-90"/>
+        </sourceConnection>
+        <child xsi:type="archimate:DiagramObject" id="289762f7-5dbc-47d6-b151-929e3c48c7a1" targetConnections="98c0b577-10d7-4b50-a784-f587880399ea" archimateElement="fede8dba-b24e-4347-9487-e9901da917f9">
+          <bounds x="22" y="52" width="148" height="47"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="27c6d20e-a463-43c0-a923-2e097816b34b" targetConnections="85cd0674-d91f-423f-aae4-eda86998820b" archimateElement="2cc22b82-8760-46b4-80cb-118fb3cb04ee" type="1">
-          <bounds x="409" y="497" width="194" height="43"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="f99d35cb-eade-4648-9f73-718fa8155c97" targetConnections="7e680171-eb4e-4d4e-931a-8da5b30f10ca" archimateElement="83a086f5-68c0-475d-88e8-c53fc033a533" type="1">
+        <bounds x="841" y="563" width="205" height="43"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" targetConnections="260d4613-78a3-4e5b-ae76-097bd7787447" archimateElement="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe">
+        <bounds x="840" y="637" width="205" height="113"/>
+        <sourceConnection xsi:type="archimate:Connection" id="7e680171-eb4e-4d4e-931a-8da5b30f10ca" source="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" target="f99d35cb-eade-4648-9f73-718fa8155c97" archimateRelationship="8d9b2549-3ec1-40a7-a2bf-709d6c667325"/>
+        <sourceConnection xsi:type="archimate:Connection" id="7248a965-43e8-4069-97bf-b5b796f79751" source="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" target="1561f4ae-0fff-4436-97ca-b2e9347b0186" archimateRelationship="3ca5b18c-b380-4be6-95f6-d6301b907ef5"/>
+        <sourceConnection xsi:type="archimate:Connection" id="2cdfbe62-9fb3-421d-bd23-f47f9b92b83a" source="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="6188230a-d639-46ea-9351-4bd0e798f98e"/>
+        <child xsi:type="archimate:DiagramObject" id="1561f4ae-0fff-4436-97ca-b2e9347b0186" targetConnections="7248a965-43e8-4069-97bf-b5b796f79751" archimateElement="10cb9a93-25d4-4da1-8964-c183b3ff910c">
+          <bounds x="20" y="47" width="152" height="55"/>
         </child>
-        <child xsi:type="archimate:DiagramObject" id="c597dd75-a908-492e-b3b2-e93e8273e81c" targetConnections="e7b59793-4e36-45a2-bb89-87bd90810527" archimateElement="b7b2aa18-f4d7-4341-945c-03837cb989a6" type="1">
-          <bounds x="412" y="742" width="196" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="22f86c10-9ab5-46f0-937a-5b6f932871d5" archimateElement="98f08e2a-55bb-4cf3-88f8-a72c328068e1">
+        <bounds x="840" y="850" width="205" height="100"/>
+        <sourceConnection xsi:type="archimate:Connection" id="1e49dc22-018d-44fc-b41c-6ffcd057e7d3" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="521a3ab7-857d-4319-b150-848d7e62010a" archimateRelationship="f4d55798-6548-4f2b-8a36-dfb103680504"/>
+        <sourceConnection xsi:type="archimate:Connection" id="496da764-66cb-4cc2-bad1-b2c5b2c3f094" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="7551b95a-b261-4058-8d05-12e2b1b33b70" archimateRelationship="dbe8aa22-0fa9-4cf4-9585-78e68a698731"/>
+        <sourceConnection xsi:type="archimate:Connection" id="88994f40-85e0-4745-850b-0816b5fe1bed" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="039e3b6f-93ce-418e-8c67-f7d608b9bab3" archimateRelationship="b1837450-f7fb-4eb5-8d35-95206ec0ad1c"/>
+        <sourceConnection xsi:type="archimate:Connection" id="7d504256-873f-49e8-ba1c-7203b9ba1c14" source="22f86c10-9ab5-46f0-937a-5b6f932871d5" target="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" archimateRelationship="4ccd9580-1076-4ab8-9e7c-51b10d00aa48"/>
+        <child xsi:type="archimate:DiagramObject" id="521a3ab7-857d-4319-b150-848d7e62010a" targetConnections="1e49dc22-018d-44fc-b41c-6ffcd057e7d3" archimateElement="e573296a-1aac-4c71-871c-1baf2417c996">
+          <bounds x="17" y="45" width="152" height="47"/>
         </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" targetConnections="7d504256-873f-49e8-ba1c-7203b9ba1c14" archimateElement="8532f211-fbcb-4255-a32d-91871c7336be">
+        <bounds x="840" y="972" width="205" height="78"/>
+        <sourceConnection xsi:type="archimate:Connection" id="3e3c38fa-20f6-451d-b15d-2451986cff47" source="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="b8077982-bc5b-42e6-baad-9a371e82443c">
+          <bendpoint startX="-627" startY="6" endX="61" endY="245"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="70c94ee9-a972-4c1b-9235-130ca7751371" source="1635b31e-8a9a-47cd-b746-e40cdf6ac5cb" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="604120c2-2acc-4b05-a43d-c707a73ad5dc">
+          <bendpoint startX="657" endX="-80" endY="239"/>
+        </sourceConnection>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="039e3b6f-93ce-418e-8c67-f7d608b9bab3" targetConnections="88994f40-85e0-4745-850b-0816b5fe1bed" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
+        <bounds x="1211" y="803" width="194" height="103"/>
+        <sourceConnection xsi:type="archimate:Connection" id="14b33f6c-8fbb-4b98-ab69-c813a1b57aca" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="454f2fd3-e258-4bc8-95d6-a5cfb9c4cdd1" archimateRelationship="dd6d220f-2e28-4568-9b32-05078dd07d50"/>
+        <sourceConnection xsi:type="archimate:Connection" id="a8e3b84c-e756-4133-9d36-ab930d551cc0" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="ce7896f2-7830-4829-bc08-5d822b5ac10b"/>
+        <sourceConnection xsi:type="archimate:Connection" id="b4a92e65-f269-4400-9519-05a1dc26d63b" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="2da9702d-601c-44de-9b5f-8ca13b2ce338" archimateRelationship="0bef2725-e92f-4ade-887e-3bd76eab034c"/>
+        <sourceConnection xsi:type="archimate:Connection" id="b52af52d-d20e-430b-a883-a49a5acb2f6b" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="a51a19f3-5152-4d56-bcb3-0da7fe52ac70" archimateRelationship="1a65f425-6273-4339-badf-15bc2122b7fa">
+          <bendpoint startX="-196" startY="-9" endX="878" endY="128"/>
+          <bendpoint startX="-196" startY="-81" endX="878" endY="56"/>
+          <bendpoint startX="-508" startY="-81" endX="566" endY="56"/>
+          <bendpoint startX="-508" startY="-141" endX="566" endY="-4"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="260d4613-78a3-4e5b-ae76-097bd7787447" source="039e3b6f-93ce-418e-8c67-f7d608b9bab3" target="1e5e83f3-e1ae-4a93-b3ca-8719f33bb059" archimateRelationship="3de150e4-3c9e-45ad-9c44-fc2dccf967a3">
+          <bendpoint startX="-136" startY="-21" endX="236" endY="160"/>
+          <bendpoint startX="-136" startY="-189" endX="236" endY="-8"/>
+        </sourceConnection>
+        <child xsi:type="archimate:DiagramObject" id="454f2fd3-e258-4bc8-95d6-a5cfb9c4cdd1" targetConnections="14b33f6c-8fbb-4b98-ab69-c813a1b57aca" archimateElement="1a8879f8-06ce-4925-93ab-ff2222e347aa">
+          <bounds x="21" y="41" width="133" height="55"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="72327a87-82a9-4f3f-98db-1c358ab5b6df" targetConnections="5a839017-abee-4fd2-a366-bdcc4915c4fe" archimateElement="0984a188-6642-400c-a42f-20277624eee9" type="1">
+        <bounds x="1512" y="459" width="274" height="93"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="88af58c4-9adf-4338-a54b-352b34d04b76" targetConnections="ded17a8a-f591-460f-8b90-be187b7e5fa3" archimateElement="7c846708-edd4-4a3a-afad-a711b21abeb4" type="1">
+        <bounds x="1211" y="992" width="194" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="0d9cde6f-9382-479a-90d5-5515d57636c8" targetConnections="6d91fde9-7faf-4783-a5f4-3500ca5de394" archimateElement="197d58a5-2131-41e0-8ec3-37bc46ed9b3d" type="1">
+        <bounds x="1248" y="156" width="129" height="68"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="4cbbb745-e6ea-4aee-977d-2178183f4ec2" targetConnections="a8e3b84c-e756-4133-9d36-ab930d551cc0 7a3a94ec-ad77-4226-83c0-b2a8ca1c7fbc 01b72cc3-d955-4da8-8b63-bd56448f9847 b14bb356-0b52-4c71-b0fa-ea36f0d27070 70c94ee9-a972-4c1b-9235-130ca7751371" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
+        <bounds x="1512" y="588" width="274" height="271"/>
+        <sourceConnection xsi:type="archimate:Connection" id="5a839017-abee-4fd2-a366-bdcc4915c4fe" source="4cbbb745-e6ea-4aee-977d-2178183f4ec2" target="72327a87-82a9-4f3f-98db-1c358ab5b6df" archimateRelationship="fec9ce18-5dfb-4483-b947-1d4dd4709b45"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="ae4559fc-cf9a-47a8-8b71-4b23a916c468" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
+        <bounds x="1212" y="265" width="196" height="105"/>
+        <sourceConnection xsi:type="archimate:Connection" id="722992ef-c758-4f34-92d7-31afeb047c65" source="ae4559fc-cf9a-47a8-8b71-4b23a916c468" target="fd503229-02f9-40f7-aeaa-5bb72030a899" archimateRelationship="b85300bf-77ed-49c7-84a8-011be915cee2"/>
+        <sourceConnection xsi:type="archimate:Connection" id="a9d606af-1e06-41f5-887f-36f8fbfade49" source="ae4559fc-cf9a-47a8-8b71-4b23a916c468" target="322d2fa3-56ad-43e4-96e3-f64f733ed393" archimateRelationship="885e9e6f-9da6-4924-8aaf-d8c5ab20552b"/>
+        <child xsi:type="archimate:DiagramObject" id="fd503229-02f9-40f7-aeaa-5bb72030a899" targetConnections="722992ef-c758-4f34-92d7-31afeb047c65" archimateElement="68e59636-1f53-4336-9cfd-64fa6acae825">
+          <bounds x="14" y="40" width="151" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="6d91fde9-7faf-4783-a5f4-3500ca5de394" source="fd503229-02f9-40f7-aeaa-5bb72030a899" target="0d9cde6f-9382-479a-90d5-5515d57636c8" archimateRelationship="caab7f6b-ecb8-4257-85ef-bbff50ef681b"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="ac0da59a-a9b6-447a-a997-b63e18573dc5" targetConnections="d55b5255-5a38-4c3d-924c-102ceb0070ff" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
+        <bounds x="1211" y="1071" width="194" height="105"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8b1528bb-d013-4d6c-abc8-c3ce341659b5" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="9404da78-8721-4fa9-b367-b99217b83f22" archimateRelationship="67b2f7a1-c01c-464b-8caa-b4a9744f35ae"/>
+        <sourceConnection xsi:type="archimate:Connection" id="7a3a94ec-ad77-4226-83c0-b2a8ca1c7fbc" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="4cbbb745-e6ea-4aee-977d-2178183f4ec2" archimateRelationship="59d8bd29-7642-49a0-9c2f-48b13fa3fdfc">
+          <bendpoint startX="338" startY="1" endX="-2" endY="356"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="ded17a8a-f591-460f-8b90-be187b7e5fa3" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="88af58c4-9adf-4338-a54b-352b34d04b76" archimateRelationship="bf3a3e9b-d6d1-4989-8ef7-021d1f136913"/>
+        <sourceConnection xsi:type="archimate:Connection" id="88c62c2e-8249-43d0-b8a7-86b4ac12694e" source="ac0da59a-a9b6-447a-a997-b63e18573dc5" target="5fa17d4e-54b9-4569-8dfe-c590cbb477ae" archimateRelationship="0e0d90ea-f06a-414b-9eab-4e425f96d110"/>
+        <child xsi:type="archimate:DiagramObject" id="9404da78-8721-4fa9-b367-b99217b83f22" targetConnections="8b1528bb-d013-4d6c-abc8-c3ce341659b5" archimateElement="51eacaa9-ed7b-4307-915c-05a114b2a19d">
+          <bounds x="21" y="41" width="141" height="55"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="2da9702d-601c-44de-9b5f-8ca13b2ce338" targetConnections="b4a92e65-f269-4400-9519-05a1dc26d63b" archimateElement="9dc22627-f969-46c8-ac76-9f1ac9b35767" type="1">
+        <bounds x="1211" y="732" width="194" height="43"/>
       </child>
       <documentation>This diagram shows how the application components (or funtions, to be decided) defined in the ISA can be deployed to nodes in the technology architecture. As the SMP and AP can be deployed both centrally within a member state but also locally at a DC/DP this diagraim shows only one variant. 
 I have made the separation between BDXL back-end and the DNS server explicit in this diagram, but this means that is not easy to show, in a vsiually nice way, that the collaboration of both realize the BDXL application component. Maybe in this diagram the BDXL server should be just one node. That for normal operations however the DNS is used hower is important for realibility. </documentation>
@@ -1115,7 +961,7 @@ I have made the separation between BDXL back-end and the DNS server explicit in 
     </element>
     <element xsi:type="archimate:ArchimateDiagramModel" name="SMP trust relations" id="8d9bd3f5-8e6a-47ea-b204-7977c8b47309">
       <child xsi:type="archimate:DiagramObject" id="44792769-b118-4dd2-946a-825257b94090" archimateElement="807ead6b-5921-4901-85ba-5aec2455149c">
-        <bounds x="504" y="205" width="157" height="55"/>
+        <bounds x="336" y="205" width="157" height="55"/>
         <sourceConnection xsi:type="archimate:Connection" id="048fd95a-0100-4078-a994-a051636b4d5d" source="44792769-b118-4dd2-946a-825257b94090" target="aa37449a-0c0f-4951-8242-e35897b4ae01" archimateRelationship="b750d5ac-710f-44b7-8821-bfdaa2f3ef44"/>
         <sourceConnection xsi:type="archimate:Connection" id="d65f3809-f2ad-471f-a1e0-6dafd7cdaed0" source="44792769-b118-4dd2-946a-825257b94090" target="e1ac229b-695b-4aee-9f3b-0e33ae5c7b77" archimateRelationship="cf8b7260-494b-471f-bfc1-b9e8189a6759"/>
         <sourceConnection xsi:type="archimate:Connection" id="1e625478-31ff-493a-ac96-5a6241f5e2e6" source="44792769-b118-4dd2-946a-825257b94090" target="d36a22e0-f8e6-4d40-ae85-3d197725631c" archimateRelationship="72d95b66-6a86-46d0-b55a-c9c8fd549c31"/>
@@ -1130,7 +976,7 @@ I have made the separation between BDXL back-end and the DNS server explicit in 
         <sourceConnection xsi:type="archimate:Connection" id="e2007b6d-cb59-439a-a38e-64d6433a7bea" source="27305808-d21e-4ff9-92fc-e50649eb7d76" target="aa37449a-0c0f-4951-8242-e35897b4ae01" archimateRelationship="f2903ebc-ce72-40b8-95f7-3c2c3f7392e6"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="e1ac229b-695b-4aee-9f3b-0e33ae5c7b77" targetConnections="b5eaf935-84aa-4ecb-ae79-a590ce08070c d65f3809-f2ad-471f-a1e0-6dafd7cdaed0 5a74aa6b-44c7-4aa7-963e-8545ecb1a979 5f11ccfa-5ee3-413c-8b64-e6765414eb69" archimateElement="013f493e-1497-459f-96e7-e31942157778">
-        <bounds x="504" y="301" width="157" height="55"/>
+        <bounds x="336" y="301" width="157" height="55"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="62f2534a-8d51-4628-86ee-7a062cc52bd3" targetConnections="e8bae1d6-2bcc-49ad-bb35-2b410ef06369" archimateElement="46993d29-c622-4da9-a827-613b19e05632">
         <bounds x="720" y="192" width="157" height="71"/>
@@ -1142,10 +988,10 @@ I have made the separation between BDXL back-end and the DNS server explicit in 
         </child>
       </child>
       <child xsi:type="archimate:DiagramObject" id="aa37449a-0c0f-4951-8242-e35897b4ae01" targetConnections="048fd95a-0100-4078-a994-a051636b4d5d e2007b6d-cb59-439a-a38e-64d6433a7bea" archimateElement="5039ff23-50cf-45d4-adba-913033c25087">
-        <bounds x="504" y="120" width="157" height="37"/>
+        <bounds x="516" y="120" width="157" height="37"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="376530c0-30d9-4a10-a7b7-d77145f529eb" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49">
-        <bounds x="96" y="204" width="157" height="55"/>
+        <bounds x="-72" y="204" width="157" height="55"/>
         <sourceConnection xsi:type="archimate:Connection" id="80b317cf-a791-4fb2-9ac6-7215ab300f0f" source="376530c0-30d9-4a10-a7b7-d77145f529eb" target="06d94da0-82a1-4e53-97db-b447659e56be" archimateRelationship="fb759bf5-b9f2-485f-84ec-95a6478d9ddb"/>
         <sourceConnection xsi:type="archimate:Connection" id="5a74aa6b-44c7-4aa7-963e-8545ecb1a979" source="376530c0-30d9-4a10-a7b7-d77145f529eb" target="e1ac229b-695b-4aee-9f3b-0e33ae5c7b77" archimateRelationship="90f3360e-3901-468f-b687-90a86c2ef36b">
           <bendpoint startX="-6" startY="93" endX="-414" endY="-4"/>
@@ -1153,15 +999,18 @@ I have made the separation between BDXL back-end and the DNS server explicit in 
         <sourceConnection xsi:type="archimate:Connection" id="9b424bfc-c4b6-4efe-93bb-8bfdb55804ac" source="376530c0-30d9-4a10-a7b7-d77145f529eb" target="7691ad2a-3349-4fa7-9e16-4a74dac1951a" archimateRelationship="687ed250-82b7-4953-b2b7-c9bb6da15ce6"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="d36a22e0-f8e6-4d40-ae85-3d197725631c" targetConnections="1e625478-31ff-493a-ac96-5a6241f5e2e6" archimateElement="f32e715b-c735-4cf9-95d5-442183d6a78e">
-        <bounds x="300" y="120" width="157" height="37"/>
+        <bounds x="132" y="120" width="157" height="37"/>
         <sourceConnection xsi:type="archimate:Connection" id="3bcc8424-6043-4a9b-a60e-a2362effee76" source="d36a22e0-f8e6-4d40-ae85-3d197725631c" target="06d94da0-82a1-4e53-97db-b447659e56be" archimateRelationship="ecb67bbc-5c83-405a-8190-286df0169aa4"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="06d94da0-82a1-4e53-97db-b447659e56be" targetConnections="3bcc8424-6043-4a9b-a60e-a2362effee76 80b317cf-a791-4fb2-9ac6-7215ab300f0f" archimateElement="ff508064-92fe-4e22-af13-af192add8998">
-        <bounds x="96" y="120" width="157" height="37"/>
+        <bounds x="-72" y="120" width="157" height="37"/>
       </child>
       <child xsi:type="archimate:DiagramObject" id="7691ad2a-3349-4fa7-9e16-4a74dac1951a" targetConnections="f4c7cf65-9284-4bc5-82b3-75e62034a98f 9b424bfc-c4b6-4efe-93bb-8bfdb55804ac" archimateElement="00da5f43-6209-4b90-98b6-66f241f28bc1">
-        <bounds x="300" y="204" width="157" height="55"/>
+        <bounds x="132" y="204" width="157" height="55"/>
         <sourceConnection xsi:type="archimate:Connection" id="5f11ccfa-5ee3-413c-8b64-e6765414eb69" source="7691ad2a-3349-4fa7-9e16-4a74dac1951a" target="e1ac229b-695b-4aee-9f3b-0e33ae5c7b77" archimateRelationship="fb5fa28b-f3fb-4ec8-91f1-e34aba0e184c"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="3bf9d08d-847e-4112-99fb-2858539d4322" archimateElement="6ec3236f-3e73-4100-8e18-cd783f289ba6">
+        <bounds x="142" y="214" width="157" height="55"/>
       </child>
     </element>
     <element xsi:type="archimate:ArchimateDiagramModel" name="Access Point trust relations" id="adf48000-69bf-4893-9c28-9872f7da95f1" viewpoint="application_usage">
@@ -1198,6 +1047,242 @@ I have made the separation between BDXL back-end and the DNS server explicit in 
         <bounds x="600" y="204" width="120" height="55"/>
         <sourceConnection xsi:type="archimate:Connection" id="30e1bb1c-7d5c-4ebc-ab3a-46562c21dfbc" source="ff514497-d485-4514-97f3-acd61e5509fa" target="1b27c6d6-5c32-4a1c-aa10-b6ec10548c1c" archimateRelationship="571b3819-03f2-4bc1-83de-20730c99666d"/>
       </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="Deployment topology #2" id="d0921795-e2cd-4015-9de7-e07627e0ad95">
+      <child xsi:type="archimate:DiagramObject" id="4fa85870-ad58-42aa-8e8f-6bf5136bd79c" fillColor="#ffd478" archimateElement="cfadf0df-e7a6-4465-ba12-5ad6e915a525">
+        <bounds x="24" y="468" width="601" height="481"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="753d2117-9b05-427c-956a-a3073d41b6c8" archimateElement="c5b9c9da-27a4-4e46-b2ca-cc396442b4ac">
+        <bounds x="1152" y="16" width="674" height="978"/>
+        <child xsi:type="archimate:DiagramObject" id="33a7600a-74b0-420b-892e-d7dde6f7440c" archimateElement="69efba2e-88ec-4e92-a231-8d4bb02b8abb">
+          <bounds x="65" y="29" width="196" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="5ac8df1c-b092-49a9-a9b3-a078e688ef31" source="33a7600a-74b0-420b-892e-d7dde6f7440c" target="e447b35f-75dd-4355-b95e-246d3832dbb4" archimateRelationship="b85300bf-77ed-49c7-84a8-011be915cee2"/>
+          <sourceConnection xsi:type="archimate:Connection" id="02add9ad-9baf-44ff-9276-ea22a7ab9a18" source="33a7600a-74b0-420b-892e-d7dde6f7440c" target="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" archimateRelationship="885e9e6f-9da6-4924-8aaf-d8c5ab20552b"/>
+          <child xsi:type="archimate:DiagramObject" id="e447b35f-75dd-4355-b95e-246d3832dbb4" targetConnections="5ac8df1c-b092-49a9-a9b3-a078e688ef31" archimateElement="68e59636-1f53-4336-9cfd-64fa6acae825">
+            <bounds x="14" y="40" width="151" height="55"/>
+            <sourceConnection xsi:type="archimate:Connection" id="93505f4e-898e-429c-b600-c0ab5df5bd36" source="e447b35f-75dd-4355-b95e-246d3832dbb4" target="a2ffe343-bff3-44ff-92a2-972d606b53bb" archimateRelationship="caab7f6b-ecb8-4257-85ef-bbff50ef681b"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="c53a4929-3d5f-4c65-8d3c-76915bb53345" targetConnections="32aca83e-e955-4bda-af6f-2502fb79965e 1e46e600-eaf2-45b9-97d8-de238cd262e4 13e78973-c275-4908-b6e0-8577f4402447 45967641-514b-49dc-bd8a-019a9c85992a e13e102d-8a57-4010-98dd-19d83ea73eff" archimateElement="76b9ee59-e6b2-40c0-9f24-ba8cedcd854e">
+          <bounds x="365" y="352" width="274" height="271"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a934f1ae-c5ee-4eae-b8af-d5ae7900353e" source="c53a4929-3d5f-4c65-8d3c-76915bb53345" target="974717e5-a94c-4c44-b047-18bf0856f163" archimateRelationship="fec9ce18-5dfb-4483-b947-1d4dd4709b45"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="017449d2-3f69-41e7-9c9a-71c9c820f770" targetConnections="c1493389-4854-47b4-abef-18c2930c676b" archimateElement="d8ff1695-d3a0-4db1-a5e4-486d8c5b7a6d">
+          <bounds x="64" y="567" width="194" height="103"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b9e2f903-e8af-4975-aaea-16e3f3aa2362" source="017449d2-3f69-41e7-9c9a-71c9c820f770" target="06cdffcb-f7d2-4bb6-8ba4-2cdf4119f6dd" archimateRelationship="dd6d220f-2e28-4568-9b32-05078dd07d50"/>
+          <sourceConnection xsi:type="archimate:Connection" id="40669824-7b73-415b-9e95-a6cdbfd890c1" source="017449d2-3f69-41e7-9c9a-71c9c820f770" target="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" archimateRelationship="3de150e4-3c9e-45ad-9c44-fc2dccf967a3">
+            <bendpoint startX="-136" startY="-21" endX="236" endY="160"/>
+            <bendpoint startX="-136" startY="-189" endX="236" endY="-8"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="32aca83e-e955-4bda-af6f-2502fb79965e" source="017449d2-3f69-41e7-9c9a-71c9c820f770" target="c53a4929-3d5f-4c65-8d3c-76915bb53345" archimateRelationship="ce7896f2-7830-4829-bc08-5d822b5ac10b"/>
+          <sourceConnection xsi:type="archimate:Connection" id="fe43bbe9-a73f-4828-afd7-f8e02bc9a8dc" source="017449d2-3f69-41e7-9c9a-71c9c820f770" target="06ca3175-d7e7-442d-a246-1d91e1342f74" archimateRelationship="0bef2725-e92f-4ade-887e-3bd76eab034c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="b9913af7-14e0-4f3c-9add-168d2b04719e" source="017449d2-3f69-41e7-9c9a-71c9c820f770" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="1a65f425-6273-4339-badf-15bc2122b7fa">
+            <bendpoint startX="-629" startY="14" endX="511" endY="-136"/>
+            <bendpoint startX="-629" startY="86" endX="511" endY="-76"/>
+          </sourceConnection>
+          <child xsi:type="archimate:DiagramObject" id="06cdffcb-f7d2-4bb6-8ba4-2cdf4119f6dd" targetConnections="b9e2f903-e8af-4975-aaea-16e3f3aa2362" archimateElement="1a8879f8-06ce-4925-93ab-ff2222e347aa">
+            <bounds x="21" y="41" width="133" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="9e568b0c-83ca-4320-8b73-8fae31ae1579" targetConnections="9f95743b-095c-4d29-9c20-817114e9c4dc" archimateElement="ca49e61c-53cc-4599-b5fd-f30b80485328">
+          <bounds x="64" y="835" width="194" height="105"/>
+          <sourceConnection xsi:type="archimate:Connection" id="e0e9d126-1d8b-4ba7-858a-58c78c1ee21d" source="9e568b0c-83ca-4320-8b73-8fae31ae1579" target="e888f54a-cfff-45ed-a540-681d0ed30999" archimateRelationship="67b2f7a1-c01c-464b-8caa-b4a9744f35ae"/>
+          <sourceConnection xsi:type="archimate:Connection" id="1e46e600-eaf2-45b9-97d8-de238cd262e4" source="9e568b0c-83ca-4320-8b73-8fae31ae1579" target="c53a4929-3d5f-4c65-8d3c-76915bb53345" archimateRelationship="59d8bd29-7642-49a0-9c2f-48b13fa3fdfc">
+            <bendpoint startX="338" startY="1" endX="-2" endY="356"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="d909a766-ea2e-426e-aa51-387c568d6bc5" source="9e568b0c-83ca-4320-8b73-8fae31ae1579" target="962c11fb-babf-4546-9114-34d9b978b0d7" archimateRelationship="bf3a3e9b-d6d1-4989-8ef7-021d1f136913"/>
+          <sourceConnection xsi:type="archimate:Connection" id="10b5017b-3e5c-41f5-a011-8b51436343b4" source="9e568b0c-83ca-4320-8b73-8fae31ae1579" target="9883dd1f-9ae4-4114-af13-96070c6ef9ce" archimateRelationship="0e0d90ea-f06a-414b-9eab-4e425f96d110"/>
+          <child xsi:type="archimate:DiagramObject" id="e888f54a-cfff-45ed-a540-681d0ed30999" targetConnections="e0e9d126-1d8b-4ba7-858a-58c78c1ee21d" archimateElement="51eacaa9-ed7b-4307-915c-05a114b2a19d">
+            <bounds x="21" y="41" width="141" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="06ca3175-d7e7-442d-a246-1d91e1342f74" targetConnections="fe43bbe9-a73f-4828-afd7-f8e02bc9a8dc" archimateElement="9dc22627-f969-46c8-ac76-9f1ac9b35767" type="1">
+          <bounds x="64" y="496" width="194" height="43"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="974717e5-a94c-4c44-b047-18bf0856f163" targetConnections="a934f1ae-c5ee-4eae-b8af-d5ae7900353e" archimateElement="0984a188-6642-400c-a42f-20277624eee9" type="1">
+          <bounds x="365" y="223" width="274" height="93"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="962c11fb-babf-4546-9114-34d9b978b0d7" targetConnections="d909a766-ea2e-426e-aa51-387c568d6bc5" archimateElement="7c846708-edd4-4a3a-afad-a711b21abeb4" type="1">
+          <bounds x="64" y="756" width="194" height="55"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="a2ffe343-bff3-44ff-92a2-972d606b53bb" targetConnections="93505f4e-898e-429c-b600-c0ab5df5bd36" archimateElement="197d58a5-2131-41e0-8ec3-37bc46ed9b3d" type="1">
+          <bounds x="365" y="57" width="129" height="68"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="821c11b1-c2ad-487c-ae4a-4d03d29ab177" archimateElement="efbf9f7a-7b30-462f-a471-3cc2049014b5">
+        <bounds x="770" y="16" width="362" height="978"/>
+        <sourceConnection xsi:type="archimate:Connection" id="56e175f3-5f7f-468c-9b9c-f42b850cc563" source="821c11b1-c2ad-487c-ae4a-4d03d29ab177" target="c6a22f36-1bf8-4972-8697-717a8a664c26" archimateRelationship="f28c0a1d-12f1-4f22-9add-268879bc8a51"/>
+        <sourceConnection xsi:type="archimate:Connection" id="356a0c10-23e5-4bf5-a8a7-21d57bb6f656" source="821c11b1-c2ad-487c-ae4a-4d03d29ab177" target="bdff6701-4961-4bfa-8a3f-049a600308e1" archimateRelationship="b42e098e-f8e9-48a6-9786-1de691e9e707"/>
+        <sourceConnection xsi:type="archimate:Connection" id="21991226-5cda-4fd4-966a-cbab851e8f67" source="821c11b1-c2ad-487c-ae4a-4d03d29ab177" target="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" archimateRelationship="8061137c-057b-42fe-b50e-08493914d415"/>
+        <child xsi:type="archimate:DiagramObject" id="c6a22f36-1bf8-4972-8697-717a8a664c26" targetConnections="56e175f3-5f7f-468c-9b9c-f42b850cc563 0c3dfdf5-c4d9-45c2-bb4f-aab6da2a518e" archimateElement="8532f211-fbcb-4255-a32d-91871c7336be">
+          <bounds x="72" y="768" width="205" height="78"/>
+          <sourceConnection xsi:type="archimate:Connection" id="13e78973-c275-4908-b6e0-8577f4402447" source="c6a22f36-1bf8-4972-8697-717a8a664c26" target="c53a4929-3d5f-4c65-8d3c-76915bb53345" archimateRelationship="604120c2-2acc-4b05-a43d-c707a73ad5dc">
+            <bendpoint startX="657" endX="-80" endY="239"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="004656db-2e6c-449a-962a-b07f2ce4d7a1" source="c6a22f36-1bf8-4972-8697-717a8a664c26" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="b8077982-bc5b-42e6-baad-9a371e82443c">
+            <bendpoint startX="-260" startY="5" endX="511" endY="44"/>
+            <bendpoint startX="-260" startY="-91" endX="511" endY="-64"/>
+          </sourceConnection>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="bdff6701-4961-4bfa-8a3f-049a600308e1" targetConnections="356a0c10-23e5-4bf5-a8a7-21d57bb6f656" archimateElement="98f08e2a-55bb-4cf3-88f8-a72c328068e1">
+          <bounds x="72" y="646" width="205" height="100"/>
+          <sourceConnection xsi:type="archimate:Connection" id="0bbc3951-2c9e-474a-9f1f-baa953a73b6b" source="bdff6701-4961-4bfa-8a3f-049a600308e1" target="54d80283-d74f-4492-891b-fdb99567b655" archimateRelationship="f4d55798-6548-4f2b-8a36-dfb103680504"/>
+          <sourceConnection xsi:type="archimate:Connection" id="0c3dfdf5-c4d9-45c2-bb4f-aab6da2a518e" source="bdff6701-4961-4bfa-8a3f-049a600308e1" target="c6a22f36-1bf8-4972-8697-717a8a664c26" archimateRelationship="4ccd9580-1076-4ab8-9e7c-51b10d00aa48"/>
+          <sourceConnection xsi:type="archimate:Connection" id="c1493389-4854-47b4-abef-18c2930c676b" source="bdff6701-4961-4bfa-8a3f-049a600308e1" target="017449d2-3f69-41e7-9c9a-71c9c820f770" archimateRelationship="b1837450-f7fb-4eb5-8d35-95206ec0ad1c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="6fd8ec93-60ef-4162-8a8d-a6d74d29fab0" source="bdff6701-4961-4bfa-8a3f-049a600308e1" target="a0e0ec31-e5e1-4c24-bf29-91efca310a31" archimateRelationship="dbe8aa22-0fa9-4cf4-9585-78e68a698731"/>
+          <child xsi:type="archimate:DiagramObject" id="54d80283-d74f-4492-891b-fdb99567b655" targetConnections="0bbc3951-2c9e-474a-9f1f-baa953a73b6b" archimateElement="e573296a-1aac-4c71-871c-1baf2417c996">
+            <bounds x="17" y="45" width="152" height="47"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" targetConnections="40669824-7b73-415b-9e95-a6cdbfd890c1 21991226-5cda-4fd4-966a-cbab851e8f67" archimateElement="77f4ba7f-cd01-4fb9-a0c2-bbf4b28501fe">
+          <bounds x="68" y="381" width="205" height="113"/>
+          <sourceConnection xsi:type="archimate:Connection" id="11e835eb-cd70-442e-9075-64b761ba2810" source="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" target="c31d96fc-1456-400e-9774-11609233c08d" archimateRelationship="3ca5b18c-b380-4be6-95f6-d6301b907ef5"/>
+          <sourceConnection xsi:type="archimate:Connection" id="ee4d70d9-aeaf-4f06-8665-f928797f7315" source="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" target="c8a0c289-e835-4b5a-a167-847da6636783" archimateRelationship="8d9b2549-3ec1-40a7-a2bf-709d6c667325"/>
+          <sourceConnection xsi:type="archimate:Connection" id="9c649f5f-3276-4fe1-be66-cdfc3b04243c" source="7a3ed4d6-7f7d-45c3-bff6-e747f56289d6" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="6188230a-d639-46ea-9351-4bd0e798f98e">
+            <bendpoint startX="-496" startY="-9" endX="271" endY="-352"/>
+          </sourceConnection>
+          <child xsi:type="archimate:DiagramObject" id="c31d96fc-1456-400e-9774-11609233c08d" targetConnections="11e835eb-cd70-442e-9075-64b761ba2810" archimateElement="10cb9a93-25d4-4da1-8964-c183b3ff910c">
+            <bounds x="20" y="47" width="152" height="55"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="3e7f4be1-e92f-4770-aa58-a896d5bd7b33" archimateElement="eb2f0fc4-68bc-4bc1-95ff-4c82b30a4349">
+          <bounds x="70" y="185" width="204" height="109"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a88fae55-8b2a-4743-9631-26cb66bcceef" source="3e7f4be1-e92f-4770-aa58-a896d5bd7b33" target="c392e5cf-8d0f-4973-80fc-2deb9dea3dc6" archimateRelationship="3dfc3dbf-5711-45b6-930a-0dc44678676a"/>
+          <sourceConnection xsi:type="archimate:Connection" id="45967641-514b-49dc-bd8a-019a9c85992a" source="3e7f4be1-e92f-4770-aa58-a896d5bd7b33" target="c53a4929-3d5f-4c65-8d3c-76915bb53345" archimateRelationship="9102c6a7-d07f-4de0-94d7-273bb7bca236">
+            <bendpoint startX="409" startY="17" endX="-307" endY="-215"/>
+            <bendpoint startX="410" startY="142" endX="-306" endY="-90"/>
+          </sourceConnection>
+          <sourceConnection xsi:type="archimate:Connection" id="dc11ca8a-747b-4bd4-965b-374fd332a36e" source="3e7f4be1-e92f-4770-aa58-a896d5bd7b33" target="f70768de-7e83-4eb0-8cbc-3acdc4117185" archimateRelationship="e08143cb-a72b-4f01-b442-a8c905603be7"/>
+          <sourceConnection xsi:type="archimate:Connection" id="bc2ab95f-e755-4f12-8a2f-954670f308c1" source="3e7f4be1-e92f-4770-aa58-a896d5bd7b33" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="5ad8159f-f033-40fd-977d-34f2694d728b">
+            <bendpoint startX="-510" startY="117" endX="259" endY="-424"/>
+          </sourceConnection>
+          <child xsi:type="archimate:DiagramObject" id="c392e5cf-8d0f-4973-80fc-2deb9dea3dc6" targetConnections="a88fae55-8b2a-4743-9631-26cb66bcceef" archimateElement="fede8dba-b24e-4347-9487-e9901da917f9">
+            <bounds x="22" y="52" width="148" height="47"/>
+          </child>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="c8a0c289-e835-4b5a-a167-847da6636783" targetConnections="ee4d70d9-aeaf-4f06-8665-f928797f7315" archimateElement="83a086f5-68c0-475d-88e8-c53fc033a533" type="1">
+          <bounds x="69" y="307" width="205" height="43"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="f70768de-7e83-4eb0-8cbc-3acdc4117185" targetConnections="dc11ca8a-747b-4bd4-965b-374fd332a36e" archimateElement="5647d2da-812c-4a0f-af6e-bac94daa4aeb" type="1">
+          <bounds x="68" y="93" width="204" height="55"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="f498b412-655e-4c37-ad15-42033b38daf8" targetConnections="16b714b1-6862-4474-908c-7a82ba113637 933947bc-bdf9-4010-8acd-646fb9319a52 0330e8be-8d7b-47af-8ba1-b2d7a58bbdd8 bc2ab95f-e755-4f12-8a2f-954670f308c1 9c649f5f-3276-4fe1-be66-cdfc3b04243c 004656db-2e6c-449a-962a-b07f2ce4d7a1 b9913af7-14e0-4f3c-9add-168d2b04719e" archimateElement="cfe6f942-99a2-4512-bf58-9be6921adb78">
+        <bounds x="36" y="660" width="274" height="272"/>
+        <sourceConnection xsi:type="archimate:Connection" id="d27225ae-63a5-4aea-9890-8aff48fe4c73" source="f498b412-655e-4c37-ad15-42033b38daf8" target="fae2bcaf-526b-4965-8721-40dad1dcfbab" archimateRelationship="65eeae27-537c-48c0-9390-455f475c2800"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="877472ed-d495-437a-b602-e25224f9b3bf" targetConnections="9d5b92bc-80d5-4870-901c-566126122564" archimateElement="2cc22b82-8760-46b4-80cb-118fb3cb04ee" type="1">
+        <bounds x="408" y="516" width="194" height="43"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="a0e0ec31-e5e1-4c24-bf29-91efca310a31" targetConnections="6fd8ec93-60ef-4162-8a8d-a6d74d29fab0" archimateElement="a46b13f6-899f-4651-bccd-67685ea0ab9d">
+        <bounds x="408" y="600" width="194" height="103"/>
+        <sourceConnection xsi:type="archimate:Connection" id="9d5b92bc-80d5-4870-901c-566126122564" source="a0e0ec31-e5e1-4c24-bf29-91efca310a31" target="877472ed-d495-437a-b602-e25224f9b3bf" archimateRelationship="32f934ac-0d3b-43d1-9f47-447f6e564ba7"/>
+        <sourceConnection xsi:type="archimate:Connection" id="0330e8be-8d7b-47af-8ba1-b2d7a58bbdd8" source="a0e0ec31-e5e1-4c24-bf29-91efca310a31" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="00c4a55a-5ec6-42e1-91fc-de97c090c9ec"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e8288ba6-ec86-465a-bf3a-873f7cbd240e" source="a0e0ec31-e5e1-4c24-bf29-91efca310a31" target="16c3c5ce-d247-46a8-a08e-ddd1f43d3273" archimateRelationship="6652b746-6c44-479c-b3e9-5f901199d7ef"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e13e102d-8a57-4010-98dd-19d83ea73eff" source="a0e0ec31-e5e1-4c24-bf29-91efca310a31" target="c53a4929-3d5f-4c65-8d3c-76915bb53345" archimateRelationship="424515ef-9f7d-470b-a218-c9f833280361">
+          <bendpoint startX="502" startY="-39" endX="-574" endY="97"/>
+          <bendpoint startX="502" startY="-159" endX="-574" endY="-23"/>
+        </sourceConnection>
+        <child xsi:type="archimate:DiagramObject" id="16c3c5ce-d247-46a8-a08e-ddd1f43d3273" targetConnections="e8288ba6-ec86-465a-bf3a-873f7cbd240e" archimateElement="8efc3e85-150e-4e1d-91f5-8989b1c5b89f">
+          <bounds x="21" y="41" width="133" height="55"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="7384ecdc-898d-48e2-84ed-4b303afadc66" targetConnections="072b9fc6-d24e-4e7b-8533-485198c0676b" archimateElement="b7b2aa18-f4d7-4341-945c-03837cb989a6" type="1">
+        <bounds x="408" y="744" width="194" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="9883dd1f-9ae4-4114-af13-96070c6ef9ce" targetConnections="10b5017b-3e5c-41f5-a011-8b51436343b4" archimateElement="c2bcebbc-2082-490d-aa5f-8606e59e3833">
+        <bounds x="408" y="828" width="194" height="105"/>
+        <sourceConnection xsi:type="archimate:Connection" id="072b9fc6-d24e-4e7b-8533-485198c0676b" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="7384ecdc-898d-48e2-84ed-4b303afadc66" archimateRelationship="d965cc0d-8876-416d-a61a-e12259efd4f9"/>
+        <sourceConnection xsi:type="archimate:Connection" id="ccf0be43-8b2f-4a66-895a-1140a7bf184a" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="5407a601-011e-4ad6-96ef-9aaec202badb" archimateRelationship="c63e1909-e2fe-4516-b642-d6749c9ad79c"/>
+        <sourceConnection xsi:type="archimate:Connection" id="933947bc-bdf9-4010-8acd-646fb9319a52" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="254d9661-8126-4963-8d40-e57116fa4186"/>
+        <sourceConnection xsi:type="archimate:Connection" id="9f95743b-095c-4d29-9c20-817114e9c4dc" source="9883dd1f-9ae4-4114-af13-96070c6ef9ce" target="9e568b0c-83ca-4320-8b73-8fae31ae1579" archimateRelationship="bce71955-7d5f-4f3d-a47c-a5b0b5af71d8"/>
+        <child xsi:type="archimate:DiagramObject" id="5407a601-011e-4ad6-96ef-9aaec202badb" targetConnections="ccf0be43-8b2f-4a66-895a-1140a7bf184a" archimateElement="cc875beb-f4ff-4952-9600-5eae35fb0d10">
+          <bounds x="21" y="41" width="141" height="55"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="fae2bcaf-526b-4965-8721-40dad1dcfbab" targetConnections="d27225ae-63a5-4aea-9890-8aff48fe4c73" archimateElement="c69264a3-6790-4058-8056-d7654ae77a75" type="1">
+        <bounds x="36" y="516" width="274" height="93"/>
+        <sourceConnection xsi:type="archimate:Connection" id="1ae0c648-04f3-4816-9273-cf429016c99a" source="fae2bcaf-526b-4965-8721-40dad1dcfbab" target="e3363b17-2ef8-40db-81e1-e99fd17b1e1a" archimateRelationship="8d84949c-da2f-456f-9c85-eb903765cea5"/>
+        <child xsi:type="archimate:DiagramObject" id="e3363b17-2ef8-40db-81e1-e99fd17b1e1a" targetConnections="1ae0c648-04f3-4816-9273-cf429016c99a" archimateElement="1480bf3c-d41d-4fea-827b-9ef9f79e6f49" type="1">
+          <bounds x="48" y="26" width="177" height="52"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="6fb1fe98-614c-4b29-93f0-982a8af99e02" targetConnections="7ab78d4c-fbd7-45fd-be95-ba07876019fe" archimateElement="5e3cba4d-6785-4a6a-80e7-ccabcb45c0e3" type="1">
+        <bounds x="240" y="84" width="129" height="68"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" targetConnections="02add9ad-9baf-44ff-9276-ea22a7ab9a18" archimateElement="538aa797-e00b-442f-af83-9a8e7e85aadd">
+        <bounds x="444" y="60" width="196" height="105"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8851b2c6-0270-4fec-92e1-e0365dcf8878" source="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" target="ed018181-fb3e-4d85-bb03-eb523a0c9fc2" archimateRelationship="49c8dabe-7bb4-4d12-b9c6-1cbd98f0c9a3"/>
+        <sourceConnection xsi:type="archimate:Connection" id="16b714b1-6862-4474-908c-7a82ba113637" source="bccc4d7c-f26e-4660-8f9d-9edf34b5d56b" target="f498b412-655e-4c37-ad15-42033b38daf8" archimateRelationship="3a2019bf-1f10-4bd8-9004-073eccf5289a"/>
+        <child xsi:type="archimate:DiagramObject" id="ed018181-fb3e-4d85-bb03-eb523a0c9fc2" targetConnections="8851b2c6-0270-4fec-92e1-e0365dcf8878" archimateElement="aae5673b-3220-4959-bd3b-a4351a94194d">
+          <bounds x="14" y="40" width="151" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="7ab78d4c-fbd7-45fd-be95-ba07876019fe" source="ed018181-fb3e-4d85-bb03-eb523a0c9fc2" target="6fb1fe98-614c-4b29-93f0-982a8af99e02" archimateRelationship="4d511da2-7df6-4beb-b47c-78b2f788e5f5"/>
+        </child>
+      </child>
+    </element>
+    <element xsi:type="archimate:ArchimateDiagramModel" name="DC process (explicit req => consent)" id="70f3574c-42f5-4e27-bd84-c86657b78b97" viewpoint="business_process_cooperation">
+      <child xsi:type="archimate:DiagramObject" id="5ebd342f-d0d0-4be9-ad29-3488601f8925" targetConnections="80271483-a477-4d07-a450-1c1004b77060" archimateElement="fad8e664-4fad-4d4a-9a10-74c710c3b97a">
+        <bounds x="717" y="61" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="e3eeb26e-92ad-44c5-b1bc-197c253da49d" archimateElement="9f9e46c6-ae4d-4a85-9885-c350181a7f9e">
+        <bounds x="61" y="203" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="e0e73020-364b-4b04-9a54-eaf8206c1e06" source="e3eeb26e-92ad-44c5-b1bc-197c253da49d" target="dace3361-d213-4d76-a946-9d83a822c0ad" archimateRelationship="04909a89-4d80-4f31-b9de-3d210fe7ed6c"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="dace3361-d213-4d76-a946-9d83a822c0ad" targetConnections="e0e73020-364b-4b04-9a54-eaf8206c1e06" archimateElement="0d63a4ac-c4aa-40ff-8653-14d682a5531f">
+        <bounds x="253" y="162" width="947" height="137"/>
+        <sourceConnection xsi:type="archimate:Connection" id="8222f18c-ff15-4e09-b96e-57fe841a0cb5" source="dace3361-d213-4d76-a946-9d83a822c0ad" target="c742fa24-b0bb-4c28-bcac-37788aceed1d" archimateRelationship="46975254-c3e9-4883-8aa3-3169ed3d7c29"/>
+        <sourceConnection xsi:type="archimate:Connection" id="80271483-a477-4d07-a450-1c1004b77060" source="dace3361-d213-4d76-a946-9d83a822c0ad" target="5ebd342f-d0d0-4be9-ad29-3488601f8925" archimateRelationship="743fde0d-4f10-435e-b6ea-04be25793ed4"/>
+        <sourceConnection xsi:type="archimate:Connection" id="105ec016-2514-4644-ae11-a706fd9e2a45" source="dace3361-d213-4d76-a946-9d83a822c0ad" target="83d80ca2-f98c-4c9b-8df4-b0b23f15ff4c" archimateRelationship="7e54ed44-7028-4eae-bb37-e4d806adce10"/>
+        <sourceConnection xsi:type="archimate:Connection" id="126eee5d-c87a-40e7-b921-f666aa3d18b2" source="dace3361-d213-4d76-a946-9d83a822c0ad" target="6faef675-433f-420f-aab3-7f46d32be731" archimateRelationship="a9b35bc6-28cd-43e7-8e11-f2a7f7717f59"/>
+        <child xsi:type="archimate:DiagramObject" id="c742fa24-b0bb-4c28-bcac-37788aceed1d" targetConnections="8222f18c-ff15-4e09-b96e-57fe841a0cb5 4170dfa7-6836-462f-858b-734dfc8c7f28" archimateElement="445db22c-cb8a-48ea-81c6-dbc99399fa91">
+          <bounds x="492" y="44" width="163" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="4ce67d0e-a7c6-4a59-87ed-c8a69bcd9c8b" source="c742fa24-b0bb-4c28-bcac-37788aceed1d" target="ce98ff8f-af3f-456c-adcb-c00fe0d1ec49" archimateRelationship="ebaeef97-a5a7-4a12-9300-5385ee892937"/>
+          <sourceConnection xsi:type="archimate:Connection" id="a9bbc353-86aa-4acb-bf99-d2678fb8e46c" source="c742fa24-b0bb-4c28-bcac-37788aceed1d" target="0e5fa200-bbc5-477c-80ad-820395b69bcd" archimateRelationship="b06ba271-aced-4fad-8e9e-4a1460837d4f"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="83d80ca2-f98c-4c9b-8df4-b0b23f15ff4c" targetConnections="105ec016-2514-4644-ae11-a706fd9e2a45 33ecc6f0-ca27-4ea8-9fc7-645eb74e5f95" archimateElement="6bc58486-8d4c-49ae-acf9-5113c4688d0a">
+          <bounds x="773" y="44" width="145" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="86e1b531-7461-465c-b5cd-70981b4cb70e" source="83d80ca2-f98c-4c9b-8df4-b0b23f15ff4c" target="79454f73-9979-4a00-96e0-c7c0052e0197" archimateRelationship="43f0f298-99a7-41e5-b998-5ae8ae89e0ca"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="f858111d-7ab7-489a-9a35-0c55479cb066" archimateElement="5711d3c1-4238-4c90-af05-6238458b576b">
+          <bounds x="24" y="44" width="169" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="71e76016-cd33-4364-9811-73be68b2b0a9" source="f858111d-7ab7-489a-9a35-0c55479cb066" target="6faef675-433f-420f-aab3-7f46d32be731" archimateRelationship="77260656-6e53-49a3-ba8b-50950c55b2e9"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="6faef675-433f-420f-aab3-7f46d32be731" targetConnections="126eee5d-c87a-40e7-b921-f666aa3d18b2 71e76016-cd33-4364-9811-73be68b2b0a9" archimateElement="9c559689-3063-4980-ba54-6c6571fdfafa">
+          <bounds x="264" y="44" width="120" height="55"/>
+          <sourceConnection xsi:type="archimate:Connection" id="ba55000e-91b7-4c36-a682-2b8ec80605cc" source="6faef675-433f-420f-aab3-7f46d32be731" target="c0c92c5b-6aa1-466a-a404-0e17b29a69d0" archimateRelationship="d5e09a47-9af8-40b6-b997-b8d222fbd40c"/>
+          <sourceConnection xsi:type="archimate:Connection" id="ae1bb0b4-cb67-48bf-87ad-bf4cc9887931" source="6faef675-433f-420f-aab3-7f46d32be731" target="81c52205-7ec1-4fdd-b3a2-846c556ecc6a" archimateRelationship="3e16413b-6f37-48ed-9564-c341b24d42cf"/>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="81c52205-7ec1-4fdd-b3a2-846c556ecc6a" targetConnections="ae1bb0b4-cb67-48bf-87ad-bf4cc9887931" archimateElement="6f2885ed-f6ec-421e-ac59-ac6e834612e0">
+          <bounds x="432" y="64" width="15" height="15"/>
+          <sourceConnection xsi:type="archimate:Connection" id="4170dfa7-6836-462f-858b-734dfc8c7f28" source="81c52205-7ec1-4fdd-b3a2-846c556ecc6a" target="c742fa24-b0bb-4c28-bcac-37788aceed1d" archimateRelationship="b6e9ec44-6ff9-496c-a13b-bae24bce49b7"/>
+          <sourceConnection xsi:type="archimate:Connection" id="5f65f691-af07-407a-bf89-91d71286cf0e" source="81c52205-7ec1-4fdd-b3a2-846c556ecc6a" target="0e5fa200-bbc5-477c-80ad-820395b69bcd" archimateRelationship="0066e76a-ca90-40ef-bdb0-4651f8ddad94">
+            <bendpoint startY="49" endX="-276" endY="49"/>
+            <bendpoint startX="276" startY="48" endY="48"/>
+          </sourceConnection>
+        </child>
+        <child xsi:type="archimate:DiagramObject" id="0e5fa200-bbc5-477c-80ad-820395b69bcd" targetConnections="a9bbc353-86aa-4acb-bf99-d2678fb8e46c 5f65f691-af07-407a-bf89-91d71286cf0e" archimateElement="bf0a70a9-46f0-42ae-95ec-ea1656923b9b">
+          <bounds x="708" y="64" width="15" height="15"/>
+          <sourceConnection xsi:type="archimate:Connection" id="33ecc6f0-ca27-4ea8-9fc7-645eb74e5f95" source="0e5fa200-bbc5-477c-80ad-820395b69bcd" target="83d80ca2-f98c-4c9b-8df4-b0b23f15ff4c" archimateRelationship="678a877f-59e8-4922-95b1-894ba143d351"/>
+        </child>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="ce98ff8f-af3f-456c-adcb-c00fe0d1ec49" targetConnections="4ce67d0e-a7c6-4a59-87ed-c8a69bcd9c8b a7eceeee-1746-41df-9180-da265e158dbd" archimateElement="53ac573b-bada-4a1a-8eb5-debaa24d3809">
+        <bounds x="768" y="336" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="c0c92c5b-6aa1-466a-a404-0e17b29a69d0" targetConnections="ba55000e-91b7-4c36-a682-2b8ec80605cc c0fa4a69-b0d3-45d6-b68a-f167b4d93fe6" archimateElement="030bea1c-c47c-49f8-89d6-8cd8d8929cf8">
+        <bounds x="517" y="340" width="120" height="55"/>
+      </child>
+      <child xsi:type="archimate:DiagramObject" id="79454f73-9979-4a00-96e0-c7c0052e0197" targetConnections="86e1b531-7461-465c-b5cd-70981b4cb70e" archimateElement="36dfdbd2-fdd9-4dc7-aa9f-d357214a8508">
+        <bounds x="1044" y="336" width="120" height="55"/>
+        <sourceConnection xsi:type="archimate:Connection" id="a7eceeee-1746-41df-9180-da265e158dbd" source="79454f73-9979-4a00-96e0-c7c0052e0197" target="ce98ff8f-af3f-456c-adcb-c00fe0d1ec49" archimateRelationship="259a3bae-99c7-4af9-8754-aa31175d39db">
+          <bendpoint startX="-24" startY="57" endX="252" endY="57"/>
+          <bendpoint startX="-278" startY="55" endX="-2" endY="55"/>
+        </sourceConnection>
+        <sourceConnection xsi:type="archimate:Connection" id="c0fa4a69-b0d3-45d6-b68a-f167b4d93fe6" source="79454f73-9979-4a00-96e0-c7c0052e0197" target="c0c92c5b-6aa1-466a-a404-0e17b29a69d0" archimateRelationship="72639f88-abea-4c10-bbbe-f33e1209959c">
+          <bendpoint startX="24" startY="69" endX="551" endY="65"/>
+          <bendpoint startX="-523" startY="65" endX="4" endY="61"/>
+        </sourceConnection>
+      </child>
+      <documentation>Based on the assumption that consent is included when the User confirms the request for getting the evidence the activity to get consent is removed from this process diagram. </documentation>
     </element>
   </folder>
 </archimate:model>


### PR DESCRIPTION
I have updated my Archimate diagrams based on our discussions during the Brussels workshop. Mostly focused on the Technology Layer diagram which now includes three deployment diagrams showing several topology options.
I also added a Application Layer diagram that gives an overview how the interfaces provided by the components are used. I think this could be used as base for analysing the security and trust requirements.